### PR TITLE
Add Variable Defined Assertion Functions

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -22,3 +22,23 @@ function(assert_false CONDITION)
     message(FATAL_ERROR "expected the condition to be false")
   endif()
 endfunction()
+
+# Asserts whether the given variable is defined.
+#
+# Arguments:
+#   - VARIABLE: The variable to assert.
+function(assert_defined VARIABLE)
+  if(NOT DEFINED "${VARIABLE}")
+    message(FATAL_ERROR "expected variable '${VARIABLE}' to be defined")
+  endif()
+endfunction()
+
+# Asserts whether the given variable is not defined.
+#
+# Arguments:
+#   - VARIABLE: The variable to assert.
+function(assert_not_defined VARIABLE)
+  if(DEFINED "${VARIABLE}")
+    message(FATAL_ERROR "expected variable '${VARIABLE}' not to be defined")
+  endif()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,4 +16,6 @@ add_cmake_test(
   cmake/AssertionTest.cmake
   "Assert a true condition"
   "Assert a false condition"
+  "Assert a defined variable"
+  "Assert an undefined variable"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -10,6 +10,15 @@ function(test_assert_a_false_condition)
   assert_false(FALSE)
 endfunction()
 
+function(test_assert_a_defined_variable)
+  set(SOME_VARIABLE "some value")
+  assert_defined(SOME_VARIABLE)
+endfunction()
+
+function(test_assert_an_undefined_variable)
+  assert_not_defined(SOME_VARIABLE)
+endfunction()
+
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
 elseif(NOT COMMAND test_${TEST_COMMAND})


### PR DESCRIPTION
This pull request resolves #9 by adding `assert_defined` and `assert_not_defined` functions alongside their corresponding tests.