### PR TITLE
Add String Equality Assertion Functions

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -42,3 +42,25 @@ function(assert_not_defined VARIABLE)
     message(FATAL_ERROR "expected variable '${VARIABLE}' not to be defined")
   endif()
 endfunction()
+
+# Asserts whether the given strings are equal.
+#
+# Arguments:
+#   - STR1: The first string to assert.
+#   - STR2: The second string to assert.
+function(assert_strequal STR1 STR2)
+  if(NOT "${STR1}" STREQUAL "${STR2}")
+    message(FATAL_ERROR "expected string '${STR1}' to be equal to '${STR2}'")
+  endif()
+endfunction()
+
+# Asserts whether the given strings are not equal.
+#
+# Arguments:
+#   - STR1: The first string to assert.
+#   - STR2: The second string to assert.
+function(assert_not_strequal STR1 STR2)
+  if("${STR1}" STREQUAL "${STR2}")
+    message(FATAL_ERROR "expected string '${STR1}' not to be equal to '${STR2}'")
+  endif()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,4 +18,6 @@ add_cmake_test(
   "Assert a false condition"
   "Assert a defined variable"
   "Assert an undefined variable"
+  "Assert equal strings"
+  "Assert unequal strings"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -19,6 +19,14 @@ function(test_assert_an_undefined_variable)
   assert_not_defined(SOME_VARIABLE)
 endfunction()
 
+function(test_assert_equal_strings)
+  assert_strequal("some string" "some string")
+endfunction()
+
+function(test_assert_unequal_strings)
+  assert_not_strequal("some string" "some other string")
+endfunction()
+
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
 elseif(NOT COMMAND test_${TEST_COMMAND})


### PR DESCRIPTION
This pull request resolves #11 by adding `assert_strequal` and `assert_not_strequal` functions alongside their corresponding tests.