### PR TITLE
Add Message Assertion Function

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -95,3 +95,28 @@ function(mock_message ENABLED)
     endfunction()
   endif()
 endfunction()
+
+# Asserts whether the 'message' function was called with the expected
+# arguments.
+#
+# This function asserts whether a message with the specified mode was called
+# with the expected message content.
+#
+# This function can only assert calls to the mocked 'message' function, which
+# is enabled by calling the 'mock_message' function.
+#
+# Arguments:
+#   - MODE: The message mode.
+#   - EXPECTED_MESSAGE: The expected message content.
+function(assert_message MODE EXPECTED_MESSAGE)
+  list(POP_FRONT ${MODE}_MESSAGES MESSAGE)
+  if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
+    string(TOLOWER "${MODE}" MODE)
+    string(REPLACE "_" " " MODE "${MODE}")
+    message(FATAL_ERROR "expected ${MODE} message '${MESSAGE}' to be equal to '${EXPECTED_MESSAGE}'")
+  endif()
+
+  if(DEFINED ${MODE}_MESSAGES)
+    set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,4 +21,5 @@ add_cmake_test(
   "Assert equal strings"
   "Assert unequal strings"
   "Mock message"
+  "Assert messages"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -27,18 +27,17 @@ function(test_assert_unequal_strings)
   assert_not_strequal("some string" "some other string")
 endfunction()
 
+function(call_sample_messages)
+  message(WARNING "some warning message")
+  message(WARNING "some other warning message")
+  message(ERROR "some error message")
+  message(FATAL_ERROR "some fatal error message")
+  message(ERROR "some other error message")
+endfunction()
+
 function(test_mock_message)
   mock_message(ON)
-
-  function(test)
-    message(WARNING "some warning message")
-    message(WARNING "some other warning message")
-    message(ERROR "some error message")
-    message(FATAL_ERROR "some fatal error message")
-    message(ERROR "some other error message")
-  endfunction()
-  test()
-
+  call_sample_messages()
   mock_message(OFF)
 
   assert_defined(WARNING_MESSAGES)
@@ -49,6 +48,17 @@ function(test_mock_message)
 
   assert_defined(FATAL_ERROR_MESSAGES)
   assert_strequal("${FATAL_ERROR_MESSAGES}" "some fatal error message")
+endfunction()
+
+function(test_assert_messages)
+  mock_message(ON)
+  call_sample_messages()
+  mock_message(OFF)
+
+  assert_message(WARNING "some warning message")
+  assert_message(WARNING "some other warning message")
+  assert_message(ERROR "some error message")
+  assert_message(FATAL_ERROR "some fatal error message")
 endfunction()
 
 if(NOT DEFINED TEST_COMMAND)


### PR DESCRIPTION
This pull request resolves #13 by adding an `assert_message` function alongside its corresponding testing. The function is used to assert whether the `message` function was called with the expected arguments.