### PR TITLE
Add Path Exists Assertion Function

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -43,6 +43,26 @@ function(assert_not_defined VARIABLE)
   endif()
 endfunction()
 
+# Asserts whether the given path exists.
+#
+# Arguments:
+#   - PATH: The path to assert.
+function(assert_exists PATH)
+  if(NOT EXISTS "${PATH}")
+    message(FATAL_ERROR "expected path '${PATH}' to exist")
+  endif()
+endfunction()
+
+# Asserts whether the given path does not exist.
+#
+# Arguments:
+#   - PATH: The path to assert.
+function(assert_not_exists PATH)
+  if(EXISTS "${PATH}")
+    message(FATAL_ERROR "expected path '${PATH}' not to exist")
+  endif()
+endfunction()
+
 # Asserts whether the given strings are equal.
 #
 # Arguments:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(add_cmake_test FILE)
   foreach(NAME ${ARGN})
     string(TOLOWER "${NAME}" TEST_COMMAND)
-    string(REPLACE " " "_" TEST_COMMAND "${TEST_COMMAND}")
+    string(REGEX REPLACE "( |-)" "_" TEST_COMMAND "${TEST_COMMAND}")
     add_test(
       NAME "${NAME}"
       COMMAND "${CMAKE_COMMAND}"
@@ -18,6 +18,8 @@ add_cmake_test(
   "Assert a false condition"
   "Assert a defined variable"
   "Assert an undefined variable"
+  "Assert an existing path"
+  "Assert a non-existing path"
   "Assert equal strings"
   "Assert unequal strings"
   "Mock message"

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -43,6 +43,28 @@ function(test_assert_an_undefined_variable)
   assert_message(FATAL_ERROR "expected variable 'SOME_VARIABLE' to be defined")
 endfunction()
 
+function(test_assert_an_existing_path)
+  file(TOUCH some-file)
+  assert_exists(some-file)
+
+  mock_message(ON)
+  assert_not_exists(some-file)
+
+  mock_message(OFF)
+  assert_message(FATAL_ERROR "expected path 'some-file' not to exist")
+endfunction()
+
+function(test_assert_a_non_existing_path)
+  file(REMOVE some-file)
+  assert_not_exists(some-file)
+
+  mock_message(ON)
+  assert_exists(some-file)
+
+  mock_message(OFF)
+  assert_message(FATAL_ERROR "expected path 'some-file' to exist")
+endfunction()
+
 function(test_assert_equal_strings)
   assert_strequal("some string" "some string")
 


### PR DESCRIPTION
This pull request resolves #17 by adding `assert_exists` and `assert_not_exists` functions alongside their testing.