### PR TITLE
Convert Mock Message Function to Behave Within a Scope

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -105,35 +105,41 @@ function(assert_not_strequal STR1 STR2)
   endif()
 endfunction()
 
-# Mocks the 'message' function.
+# Begins a scope for mocking the 'message' function.
 #
-# If enabled, this function will mock the 'message' function by modifying its
-# behavior to store the message into a list variable instead of printing it to
-# the log.
+# This function begins a scope for mocking the 'message' function by modifying
+# its behavior to store the message into a list variable instead of printing it
+# to the log.
 #
-# Arguments:
-#   - ENABLED: Whether to mock the 'message' function or not.
-function(mock_message ENABLED)
-  if("${ENABLED}")
-    set_property(GLOBAL PROPERTY message_mocked "${ENABLED}")
+# Use the 'end_mock_message' function to end the scope for mocking the
+# 'message' function, reverting it to the original behavior.
+function(mock_message)
+  set_property(GLOBAL PROPERTY message_mocked ON)
 
-    macro(message MODE MESSAGE)
-      get_property(ENABLED GLOBAL PROPERTY message_mocked)
-      if("${ENABLED}")
-        list(APPEND ${MODE}_MESSAGES "${MESSAGE}")
-        set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
-        if("${MODE}" STREQUAL FATAL_ERROR)
-          return()
-        endif()
-      else()
-        _message("${MODE}" "${MESSAGE}")
+  macro(message MODE MESSAGE)
+    get_property(ENABLED GLOBAL PROPERTY message_mocked)
+    if("${ENABLED}")
+      list(APPEND ${MODE}_MESSAGES "${MESSAGE}")
+      set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
+      if("${MODE}" STREQUAL FATAL_ERROR)
+        return()
       endif()
-    endmacro()
+    else()
+      _message("${MODE}" "${MESSAGE}")
+    endif()
+  endmacro()
 
-    function(mock_message ENABLED)
-      set_property(GLOBAL PROPERTY message_mocked "${ENABLED}")
-    endfunction()
-  endif()
+  function(mock_message)
+    set_property(GLOBAL PROPERTY message_mocked ON)
+  endfunction()
+endfunction()
+
+# Ends a scope for mocking the 'message' function.
+#
+# This function ends the scope for mocking the 'message' function, reverting it
+# to the original behavior.
+function(end_mock_message)
+  set_property(GLOBAL PROPERTY message_mocked OFF)
 endfunction()
 
 # Asserts whether the 'message' function was called with the expected

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -5,20 +5,18 @@ include(Assertion)
 function(test_assert_a_true_condition)
   assert_true(TRUE)
 
-  mock_message(ON)
-  assert_false(TRUE)
-
-  mock_message(OFF)
+  mock_message()
+    assert_false(TRUE)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected the condition to be false")
 endfunction()
 
 function(test_assert_a_false_condition)
   assert_false(FALSE)
 
-  mock_message(ON)
-  assert_true(FALSE)
-
-  mock_message(OFF)
+  mock_message()
+    assert_true(FALSE)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected the condition to be true")
 endfunction()
 
@@ -26,20 +24,18 @@ function(test_assert_a_defined_variable)
   set(SOME_VARIABLE "some value")
   assert_defined(SOME_VARIABLE)
 
-  mock_message(ON)
-  assert_not_defined(SOME_VARIABLE)
-
-  mock_message(OFF)
+  mock_message()
+    assert_not_defined(SOME_VARIABLE)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected variable 'SOME_VARIABLE' not to be defined")
 endfunction()
 
 function(test_assert_an_undefined_variable)
   assert_not_defined(SOME_VARIABLE)
 
-  mock_message(ON)
-  assert_defined(SOME_VARIABLE)
-
-  mock_message(OFF)
+  mock_message()
+    assert_defined(SOME_VARIABLE)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected variable 'SOME_VARIABLE' to be defined")
 endfunction()
 
@@ -48,16 +44,14 @@ function(test_assert_a_file_path)
 
   assert_exists(some-file)
 
-  mock_message(ON)
-  assert_not_exists(some-file)
-
-  mock_message(OFF)
+  mock_message()
+    assert_not_exists(some-file)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected path 'some-file' not to exist")
 
-  mock_message(ON)
-  assert_directory(some-file)
-
-  mock_message(OFF)
+  mock_message()
+    assert_directory(some-file)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected path 'some-file' to be a directory")
 
   assert_not_directory(some-file)
@@ -68,18 +62,16 @@ function(test_assert_a_directory_path)
 
   assert_exists(some-directory)
 
-  mock_message(ON)
-  assert_not_exists(some-directory)
-
-  mock_message(OFF)
+  mock_message()
+    assert_not_exists(some-directory)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected path 'some-directory' not to exist")
 
   assert_directory(some-directory)
 
-  mock_message(ON)
-  assert_not_directory(some-directory)
-
-  mock_message(OFF)
+  mock_message()
+    assert_not_directory(some-directory)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected path 'some-directory' not to be a directory")
 endfunction()
 
@@ -87,30 +79,27 @@ function(test_assert_a_non_existing_path)
   file(REMOVE some-non-existing-file)
   assert_not_exists(some-non-existing-file)
 
-  mock_message(ON)
-  assert_exists(some-non-existing-file)
-
-  mock_message(OFF)
+  mock_message()
+    assert_exists(some-non-existing-file)
+  end_mock_message()
   assert_message(FATAL_ERROR "expected path 'some-non-existing-file' to exist")
 endfunction()
 
 function(test_assert_equal_strings)
   assert_strequal("some string" "some string")
 
-  mock_message(ON)
-  assert_not_strequal("some string" "some string")
-
-  mock_message(OFF)
+  mock_message()
+    assert_not_strequal("some string" "some string")
+  end_mock_message()
   assert_message(FATAL_ERROR "expected string 'some string' not to be equal to 'some string'")
 endfunction()
 
 function(test_assert_unequal_strings)
   assert_not_strequal("some string" "some other string")
 
-  mock_message(ON)
-  assert_strequal("some string" "some other string")
-
-  mock_message(OFF)
+  mock_message()
+    assert_strequal("some string" "some other string")
+  end_mock_message()
   assert_message(FATAL_ERROR "expected string 'some string' to be equal to 'some other string'")
 endfunction()
 
@@ -123,10 +112,10 @@ function(call_sample_messages)
 endfunction()
 
 function(test_mock_message)
-  mock_message(ON)
-  call_sample_messages()
+  mock_message()
+    call_sample_messages()
+  end_mock_message()
 
-  mock_message(OFF)
   assert_defined(WARNING_MESSAGES)
   assert_strequal("${WARNING_MESSAGES}" "some warning message;some other warning message")
 
@@ -138,19 +127,18 @@ function(test_mock_message)
 endfunction()
 
 function(test_assert_messages)
-  mock_message(ON)
-  call_sample_messages()
+  mock_message()
+    call_sample_messages()
+  end_mock_message()
 
-  mock_message(OFF)
   assert_message(WARNING "some warning message")
   assert_message(WARNING "some other warning message")
   assert_message(ERROR "some error message")
   assert_message(FATAL_ERROR "some fatal error message")
 
-  mock_message(ON)
-  assert_message(ERROR "some other error message")
-
-  mock_message(OFF)
+  mock_message()
+    assert_message(ERROR "some other error message")
+  end_mock_message()
   assert_message(FATAL_ERROR "expected error message '' to be equal to 'some other error message'")
 endfunction()
 


### PR DESCRIPTION
This pull request resolves #21 by modifying the `mock_message` function to behave within a scope, removing its `ENABLED` argument, and adding a new `end_mock_message` function in the process.