### PR TITLE
Fix Typo in the Example Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ assert_false(FALSE)
 set(SOME_VARIABLE "some value")
 
 assert_defined(SOME_VARIABLE)
-assert_strequal("${SOME_VALUE}" "some value")
+assert_strequal("${SOME_VARIABLE}" "some value")
 
 file(TOUCH some-file)
 


### PR DESCRIPTION
This pull request simply fixes a typo in the `SOME_VARIABLE` variable in the example usage section of the `README.md` file.