### PR TITLE
Trigger Deploy Workflow on Push Tag Events

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    tags: ["**"]
 jobs:
   deploy-pages:
     name: Deploy Pages

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Copy Modules
         run: |
           mkdir -p build/page
-          cp cmake/Assertion.cmake build/page/$(git branch --show-current)
+          git checkout main
+          cp cmake/Assertion.cmake build/page/main
           for tag in $(git tag); do
             git checkout $tag
             cp cmake/Assertion.cmake build/page/$tag


### PR DESCRIPTION
This pull request resolves #32 by triggering the Deploy workflow on push tag events as well. This change also fixes a step in the Deploy workflow to copy the `Assertion.cmake` module from the `main` branch instead of the current branch.