### PR TITLE
Add Regular Expression Match Assertion Function

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -83,6 +83,28 @@ function(assert_not_directory PATH)
   endif()
 endfunction()
 
+# Asserts whether the given string matches the given regular expression.
+#
+# Arguments:
+#   - STRING: The string to assert.
+#   - REGEX: The regular expression to match against the string.
+function(assert_matches STRING REGEX)
+  if(NOT "${STRING}" MATCHES "${REGEX}")
+    message(FATAL_ERROR "expected string '${STRING}' to match '${REGEX}'")
+  endif()
+endfunction()
+
+# Asserts whether the given string does not match the given regular expression.
+#
+# Arguments:
+#   - STRING: The string to assert.
+#   - REGEX: The regular expression to match against the string.
+function(assert_not_matches STRING REGEX)
+  if("${STRING}" MATCHES "${REGEX}")
+    message(FATAL_ERROR "expected string '${STRING}' not to match '${REGEX}'")
+  endif()
+endfunction()
+
 # Asserts whether the given strings are equal.
 #
 # Arguments:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,8 @@ add_cmake_test(
   "Assert a file path"
   "Assert a directory path"
   "Assert a non-existing path"
+  "Assert a matching regular expression"
+  "Assert an unmatching regular expression"
   "Assert equal strings"
   "Assert unequal strings"
   "Mock message"

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -85,6 +85,24 @@ function("Assert a non-existing path")
   assert_message(FATAL_ERROR "expected path 'some-non-existing-file' to exist")
 endfunction()
 
+function("Assert a matching regular expression")
+  assert_matches("some string" "so.*ing")
+
+  mock_message()
+    assert_not_matches("some string" "so.*ing")
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected string 'some string' not to match 'so.*ing'")
+endfunction()
+
+function("Assert an unmatching regular expression")
+  mock_message()
+    assert_matches("some string" "so.*other.*ing")
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected string 'some string' to match 'so.*other.*ing'")
+
+  assert_not_matches("some string" "so.*other.*ing")
+endfunction()
+
 function("Assert equal strings")
   assert_strequal("some string" "some string")
 


### PR DESCRIPTION
This pull request resolves #34 by adding the `assert_matches` and `assert_not_matches` functions alongside their tests.