### PR TITLE
Add Execute Process Assertion Functions

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -188,3 +188,27 @@ function(assert_message MODE EXPECTED_MESSAGE)
     set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
   endif()
 endfunction()
+
+# Asserts whether the given command successfully executes a process.
+#
+# Arguments:
+#   - ARGN: The command to execute.
+function(assert_execute_process)
+  execute_process(COMMAND ${ARGN} RESULT_VARIABLE RES)
+  if(NOT RES EQUAL 0)
+    string(REPLACE ";" " " ARGUMENTS "${ARGN}")
+    message(FATAL_ERROR "expected command '${ARGUMENTS}' not to fail (exit code: ${RES})")
+  endif()
+endfunction()
+
+# Asserts whether the given command fails to execute a process.
+#
+# Arguments:
+#   - ARGN: The command to execute.
+function(assert_not_execute_process)
+  execute_process(COMMAND ${ARGN} RESULT_VARIABLE RES)
+  if(RES EQUAL 0)
+    string(REPLACE ";" " " ARGUMENTS "${ARGN}")
+    message(FATAL_ERROR "expected command '${ARGUMENTS}' to fail (exit code: ${RES})")
+  endif()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,4 +25,6 @@ add_cmake_test(
   "Assert unequal strings"
   "Mock message"
   "Assert messages"
+  "Assert successful process execution"
+  "Assert failed process execution"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -160,4 +160,22 @@ function("Assert messages")
   assert_message(FATAL_ERROR "expected error message '' to be equal to 'some other error message'")
 endfunction()
 
+function("Assert successful process execution")
+  assert_execute_process("${CMAKE_COMMAND}" -E true)
+
+  mock_message()
+    assert_not_execute_process("${CMAKE_COMMAND}" -E true)
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected command '${CMAKE_COMMAND} -E true' to fail (exit code: 0)")
+endfunction()
+
+function("Assert failed process execution")
+  mock_message()
+    assert_execute_process("${CMAKE_COMMAND}" -E false)
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected command '${CMAKE_COMMAND} -E false' not to fail (exit code: 1)")
+
+  assert_not_execute_process("${CMAKE_COMMAND}" -E false)
+endfunction()
+
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #36 by adding the `assert_execute_process` and `assert_not_execute_process` assertion functions alongside their tests.