### PR TITLE
Add Expected Output Option to Execute Process Assertion Function

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -193,11 +193,18 @@ endfunction()
 #
 # Arguments:
 #   - ARGN: The command to execute.
+#
+# Optional arguments:
+#   - EXPECTED_OUTPUT: If set, asserts whether the output of the executed
+#     process matches the given regular expression.
 function(assert_execute_process)
-  execute_process(COMMAND ${ARGN} RESULT_VARIABLE RES)
+  cmake_parse_arguments(ARG "" "EXPECTED_OUTPUT" "" ${ARGN})
+  execute_process(COMMAND ${ARG_UNPARSED_ARGUMENTS} RESULT_VARIABLE RES OUTPUT_VARIABLE OUT)
+  string(REPLACE ";" " " ARGUMENTS "${ARG_UNPARSED_ARGUMENTS}")
   if(NOT RES EQUAL 0)
-    string(REPLACE ";" " " ARGUMENTS "${ARGN}")
     message(FATAL_ERROR "expected command '${ARGUMENTS}' not to fail (exit code: ${RES})")
+  elseif(DEFINED ARG_EXPECTED_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_EXPECTED_OUTPUT}")
+    message(FATAL_ERROR "expected the output of command '${ARGUMENTS}' to match '${ARG_EXPECTED_OUTPUT}'")
   endif()
 endfunction()
 
@@ -205,10 +212,17 @@ endfunction()
 #
 # Arguments:
 #   - ARGN: The command to execute.
+#
+# Optional arguments:
+#   - EXPECTED_OUTPUT: If set, asserts whether the output of the executed
+#     process matches the given regular expression.
 function(assert_not_execute_process)
-  execute_process(COMMAND ${ARGN} RESULT_VARIABLE RES)
+  cmake_parse_arguments(ARG "" "EXPECTED_OUTPUT" "" ${ARGN})
+  execute_process(COMMAND ${ARG_UNPARSED_ARGUMENTS} RESULT_VARIABLE RES ERROR_VARIABLE ERR)
+  string(REPLACE ";" " " ARGUMENTS "${ARG_UNPARSED_ARGUMENTS}")
   if(RES EQUAL 0)
-    string(REPLACE ";" " " ARGUMENTS "${ARGN}")
     message(FATAL_ERROR "expected command '${ARGUMENTS}' to fail (exit code: ${RES})")
+  elseif(DEFINED ARG_EXPECTED_OUTPUT AND NOT "${ERR}" MATCHES "${ARG_EXPECTED_OUTPUT}")
+    message(FATAL_ERROR "expected the output of command '${ARGUMENTS}' to match '${ARG_EXPECTED_OUTPUT}'")
   endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,4 +27,6 @@ add_cmake_test(
   "Assert messages"
   "Assert successful process execution"
   "Assert failed process execution"
+  "Assert matching process execution output"
+  "Assert non-matching process execution output"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -178,4 +178,34 @@ function("Assert failed process execution")
   assert_not_execute_process("${CMAKE_COMMAND}" -E false)
 endfunction()
 
+function("Assert matching process execution output")
+  assert_execute_process(
+    "${CMAKE_COMMAND}" -E echo "Hello world!"
+    EXPECTED_OUTPUT "Hello.*!"
+  )
+
+  assert_not_execute_process(
+    "${CMAKE_COMMAND}" -E invalid
+    EXPECTED_OUTPUT "CMake Error:.*Available commands:"
+  )
+endfunction()
+
+function("Assert non-matching process execution output")
+  mock_message()
+    assert_execute_process(
+      "${CMAKE_COMMAND}" -E echo "Hello world!"
+      EXPECTED_OUTPUT "Hi.*!"
+    )
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected the output of command '${CMAKE_COMMAND} -E echo Hello world!' to match 'Hi.*!'")
+
+  mock_message()
+    assert_not_execute_process(
+      "${CMAKE_COMMAND}" -E invalid
+      EXPECTED_OUTPUT "CMake Error:.*Unavailable commands:"
+    )
+  end_mock_message()
+  assert_message(FATAL_ERROR "expected the output of command '${CMAKE_COMMAND} -E invalid' to match 'CMake Error:.*Unavailable commands:'")
+endfunction()
+
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #39 by adding the `EXPECTED_OUTPUT` option to the `assert_execute_process` and `assert_not_execute_process` functions. This change also updates the tests to follow the new behavior.