### PR TITLE
Merge Process Execution Assertion Functions into Assert Function

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,9 +19,6 @@ add_cmake_test(
   "Regular expression match assertions"
   "String equality assertions"
   "Message assertions"
+  "Process execution assertions"
   "Mock message"
-  "Assert successful process execution"
-  "Assert failed process execution"
-  "Assert matching process execution output"
-  "Assert non-matching process execution output"
 )


### PR DESCRIPTION
This pull request resolves #48 by merging the `assert_execute_process` and `assert_not_execute_process` functions into the `assert` function.