### PR TITLE
Separate Message and Execute Process Assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ mock_message()
   message(ERROR "some error message")
 end_mock_message()
 
-assert(MESSAGE STATUS "some status message")
-assert(MESSAGE ERROR "some error message")
+assert_message(STATUS "some status message")
+assert_message(ERROR "some error message")
 ```
 
 ## License

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -12,43 +12,19 @@ include_guard(GLOBAL)
 # perform the assertion.
 #
 # Aside from the assertions specified in the documentation of the 'if' function,
-# this function also supports mocked message and execute process assertions.
-#
-# The mocked message assertion can be done by calling 'assert(MESSAGE <MODE>
-# <EXPECTED_MESSAGE>)', where 'MODE' is the message mode and 'EXPECTED_MESSAGE'
-# is the expected message.
-#
-# The execute process assertion can be done by calling 'assert(EXECUTE_PROCESS
-# [COMMAND COMMAND ARG...] [RESULT EXPECTED_RESULT] [OUTPUT EXPECTED_OUTPUT]
-# [ERROR EXPECTED_ERROR])', where 'COMMAND ARG...' is the command to be
-# executed, 'EXPECTED_RESULT' is the expected process exit code,
-# 'EXPECTED_OUTPUT' is the expected process output, and 'EXPECTED_ERROR' is the
-# expected process error.
+# this function also supports execute process assertions by calling
+# 'assert(EXECUTE_PROCESS [COMMAND COMMAND ARG...] [RESULT EXPECTED_RESULT]
+# [OUTPUT EXPECTED_OUTPUT] [ERROR EXPECTED_ERROR])', where 'COMMAND ARG...' is
+# the command to be executed, 'EXPECTED_RESULT' is the expected process exit
+# code, 'EXPECTED_OUTPUT' is the expected process output, and 'EXPECTED_ERROR'
+# is the expected process error.
 function(assert)
   list(LENGTH ARGN ARGUMENTS_LENGTH)
   if(ARGUMENTS_LENGTH GREATER 0)
     set(ARGUMENTS ${ARGN})
 
     list(GET ARGUMENTS 0 ASSERTION)
-    if(ASSERTION STREQUAL MESSAGE)
-      list(LENGTH ARGUMENTS ARGUMENTS_LENGTH)
-      if(ARGUMENTS_LENGTH LESS 3)
-        message(FATAL_ERROR "usage: assert(MESSAGE <MODE> <EXPECTED_MESSAGE>)")
-      endif()
-      list(GET ARGUMENTS 1 MODE)
-      list(GET ARGUMENTS 2 EXPECTED_MESSAGE)
-
-      list(POP_FRONT ${MODE}_MESSAGES MESSAGE)
-      if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
-        string(TOLOWER "${MODE}" MODE)
-        string(REPLACE "_" " " MODE "${MODE}")
-        message(FATAL_ERROR "expected ${MODE} message '${MESSAGE}' to be equal to '${EXPECTED_MESSAGE}'")
-      endif()
-
-      if(DEFINED ${MODE}_MESSAGES)
-        set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
-      endif()
-    elseif(ASSERTION STREQUAL EXECUTE_PROCESS)
+    if(ASSERTION STREQUAL EXECUTE_PROCESS)
       list(REMOVE_AT ARGUMENTS 0)
       cmake_parse_arguments(ARG "" "RESULT;OUTPUT;ERROR" "COMMAND" ${ARGUMENTS})
 
@@ -169,4 +145,28 @@ endfunction()
 # to the original behavior.
 function(end_mock_message)
   set_property(GLOBAL PROPERTY message_mocked OFF)
+endfunction()
+
+# Asserts whether the 'message' function was called with the expected arguments.
+#
+# This function asserts whether a message with the specified mode was called
+# with the expected message content.
+#
+# This function can only assert calls to the mocked 'message' function, which is
+# enabled by calling the 'mock_message' function.
+#
+# Arguments:
+#   - MODE: The message mode.
+#   - EXPECTED_MESSAGE: The expected message content.
+function(assert_message MODE EXPECTED_MESSAGE)
+  list(POP_FRONT ${MODE}_MESSAGES MESSAGE)
+  if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
+    string(TOLOWER "${MODE}" MODE)
+    string(REPLACE "_" " " MODE "${MODE}")
+    message(FATAL_ERROR "expected ${MODE} message '${MESSAGE}' to be equal to '${EXPECTED_MESSAGE}'")
+  endif()
+
+  if(DEFINED ${MODE}_MESSAGES)
+    set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
+  endif()
 endfunction()

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -10,101 +10,60 @@ include_guard(GLOBAL)
 #
 # Refer to the documentation of the 'if' function for supported conditions to
 # perform the assertion.
-#
-# Aside from the assertions specified in the documentation of the 'if' function,
-# this function also supports execute process assertions by calling
-# 'assert(EXECUTE_PROCESS [COMMAND COMMAND ARG...] [RESULT EXPECTED_RESULT]
-# [OUTPUT EXPECTED_OUTPUT] [ERROR EXPECTED_ERROR])', where 'COMMAND ARG...' is
-# the command to be executed, 'EXPECTED_RESULT' is the expected process exit
-# code, 'EXPECTED_OUTPUT' is the expected process output, and 'EXPECTED_ERROR'
-# is the expected process error.
 function(assert)
   list(LENGTH ARGN ARGUMENTS_LENGTH)
   if(ARGUMENTS_LENGTH GREATER 0)
     set(ARGUMENTS ${ARGN})
 
-    list(GET ARGUMENTS 0 ASSERTION)
-    if(ASSERTION STREQUAL EXECUTE_PROCESS)
+    # Determines whether the given arguments start with 'NOT'.
+    list(GET ARGUMENTS 0 ARGUMENTS_0)
+    if(ARGUMENTS_0 STREQUAL NOT)
       list(REMOVE_AT ARGUMENTS 0)
-      cmake_parse_arguments(ARG "" "RESULT;OUTPUT;ERROR" "COMMAND" ${ARGUMENTS})
-
-      execute_process(
-        COMMAND ${ARG_COMMAND}
-        RESULT_VARIABLE RES
-        OUTPUT_VARIABLE OUT
-        ERROR_VARIABLE ERR
-      )
-
-      if(DEFINED ARG_RESULT AND NOT RES EQUAL "${ARG_RESULT}")
-        string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-        message(
-          FATAL_ERROR
-          "expected command '${ARG_COMMAND}' to exit with status ${ARG_RESULT}"
-        )
-      elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
-        string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-        message(
-          FATAL_ERROR
-          "expected the output of command '${ARG_COMMAND}' to match '${ARG_OUTPUT}'"
-        )
-      elseif(DEFINED ARG_ERROR AND NOT "${ERR}" MATCHES "${ARG_ERROR}")
-        string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-        message(
-          FATAL_ERROR
-          "expected the error of command '${ARG_COMMAND}' to match '${ARG_ERROR}'"
-        )
-      endif()
+      set(BOOLEAN_WORD " false")
+      set(NOT_WORD " not")
     else()
-      # Determines whether the given arguments start with 'NOT'.
-      list(GET ARGUMENTS 0 ARGUMENTS_0)
-      if(ARGUMENTS_0 STREQUAL NOT)
-        list(REMOVE_AT ARGUMENTS 0)
-        set(BOOLEAN_WORD " false")
-        set(NOT_WORD " not")
+      set(ARGUMENT_NOT NOT)
+      set(BOOLEAN_WORD " true")
+    endif()
+
+    list(LENGTH ARGUMENTS ARGUMENTS_LENGTH)
+    if(ARGUMENTS_LENGTH EQUAL 2)
+      list(GET ARGUMENTS 0 OPERATOR)
+      list(GET ARGUMENTS 1 VALUE)
+
+      if(OPERATOR STREQUAL DEFINED)
+        set(MESSAGE "expected variable '${VALUE}'${NOT_WORD} to be defined")
+      elseif(OPERATOR STREQUAL EXISTS)
+        set(MESSAGE "expected path '${VALUE}'${NOT_WORD} to exist")
+      elseif(OPERATOR STREQUAL IS_DIRECTORY)
+        set(MESSAGE "expected path '${VALUE}'${NOT_WORD} to be a directory")
+      endif()
+    elseif(ARGUMENTS_LENGTH EQUAL 3)
+      list(GET ARGUMENTS 0 LEFT_VALUE)
+      list(GET ARGUMENTS 1 OPERATOR)
+      list(GET ARGUMENTS 2 RIGHT_VALUE)
+
+      if(OPERATOR STREQUAL MATCHES)
+        if(DEFINED "${LEFT_VALUE}")
+          set(LEFT_VALUE "${${LEFT_VALUE}}")
+        endif()
+        set(MESSAGE "expected string '${LEFT_VALUE}'${NOT_WORD} to match '${RIGHT_VALUE}'")
+      elseif(OPERATOR STREQUAL STREQUAL)
+        if(DEFINED "${LEFT_VALUE}")
+          set(LEFT_VALUE "${${LEFT_VALUE}}")
+        endif()
+        if(DEFINED "${RIGHT_VALUE}")
+          set(RIGHT_VALUE "${${RIGHT_VALUE}}")
+        endif()
+        set(MESSAGE "expected string '${LEFT_VALUE}'${NOT_WORD} to be equal to '${RIGHT_VALUE}'")
+      endif()
+    endif()
+
+    if(${ARGUMENT_NOT} ${ARGUMENTS})
+      if(DEFINED MESSAGE)
+        message(FATAL_ERROR "${MESSAGE}")
       else()
-        set(ARGUMENT_NOT NOT)
-        set(BOOLEAN_WORD " true")
-      endif()
-
-      list(LENGTH ARGUMENTS ARGUMENTS_LENGTH)
-      if(ARGUMENTS_LENGTH EQUAL 2)
-        list(GET ARGUMENTS 0 OPERATOR)
-        list(GET ARGUMENTS 1 VALUE)
-
-        if(OPERATOR STREQUAL DEFINED)
-          set(MESSAGE "expected variable '${VALUE}'${NOT_WORD} to be defined")
-        elseif(OPERATOR STREQUAL EXISTS)
-          set(MESSAGE "expected path '${VALUE}'${NOT_WORD} to exist")
-        elseif(OPERATOR STREQUAL IS_DIRECTORY)
-          set(MESSAGE "expected path '${VALUE}'${NOT_WORD} to be a directory")
-        endif()
-      elseif(ARGUMENTS_LENGTH EQUAL 3)
-        list(GET ARGUMENTS 0 LEFT_VALUE)
-        list(GET ARGUMENTS 1 OPERATOR)
-        list(GET ARGUMENTS 2 RIGHT_VALUE)
-
-        if(OPERATOR STREQUAL MATCHES)
-          if(DEFINED "${LEFT_VALUE}")
-            set(LEFT_VALUE "${${LEFT_VALUE}}")
-          endif()
-          set(MESSAGE "expected string '${LEFT_VALUE}'${NOT_WORD} to match '${RIGHT_VALUE}'")
-        elseif(OPERATOR STREQUAL STREQUAL)
-          if(DEFINED "${LEFT_VALUE}")
-            set(LEFT_VALUE "${${LEFT_VALUE}}")
-          endif()
-          if(DEFINED "${RIGHT_VALUE}")
-            set(RIGHT_VALUE "${${RIGHT_VALUE}}")
-          endif()
-          set(MESSAGE "expected string '${LEFT_VALUE}'${NOT_WORD} to be equal to '${RIGHT_VALUE}'")
-        endif()
-      endif()
-
-      if(${ARGUMENT_NOT} ${ARGUMENTS})
-        if(DEFINED MESSAGE)
-          message(FATAL_ERROR "${MESSAGE}")
-        else()
-          message(FATAL_ERROR "expected '${ARGUMENTS}' to resolve to${BOOLEAN_WORD}")
-        endif()
+        message(FATAL_ERROR "expected '${ARGUMENTS}' to resolve to${BOOLEAN_WORD}")
       endif()
     endif()
   endif()
@@ -168,5 +127,46 @@ function(assert_message MODE EXPECTED_MESSAGE)
 
   if(DEFINED ${MODE}_MESSAGES)
     set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Asserts whether the given command successfully executes a process.
+#
+# Optional arguments:
+#   - COMMAND: The command to execute.
+#   - RESULT: If set, asserts whether the executed process exits with the given
+#     status.
+#   - OUTPUT: If set, asserts whether the output of the executed process matches
+#     the given regular expression.
+#   - ERROR: If set, asserts whether the error of the executed process matches
+#     the given regular expression.
+function(assert_execute_process)
+  cmake_parse_arguments(ARG "" "RESULT;OUTPUT;ERROR" "COMMAND" ${ARGN})
+
+  execute_process(
+    COMMAND ${ARG_COMMAND}
+    RESULT_VARIABLE RES
+    OUTPUT_VARIABLE OUT
+    ERROR_VARIABLE ERR
+  )
+
+  if(DEFINED ARG_RESULT AND NOT RES EQUAL "${ARG_RESULT}")
+    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
+    message(
+      FATAL_ERROR
+      "expected command '${ARG_COMMAND}' to exit with status ${ARG_RESULT}"
+    )
+  elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
+    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
+    message(
+      FATAL_ERROR
+      "expected the output of command '${ARG_COMMAND}' to match '${ARG_OUTPUT}'"
+    )
+  elseif(DEFINED ARG_ERROR AND NOT "${ERR}" MATCHES "${ARG_ERROR}")
+    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
+    message(
+      FATAL_ERROR
+      "expected the error of command '${ARG_COMMAND}' to match '${ARG_ERROR}'"
+    )
   endif()
 endfunction()

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -168,14 +168,14 @@ function("Message assertions")
 endfunction()
 
 function("Process execution assertions")
-  assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E true)
-  assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E false)
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true)
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
 
-  assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E true RESULT 0)
-  assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E false RESULT 1)
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true RESULT 0)
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false RESULT 1)
 
   mock_message()
-    assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E true RESULT 1)
+    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true RESULT 1)
   end_mock_message()
   assert_message(
     FATAL_ERROR
@@ -183,21 +183,21 @@ function("Process execution assertions")
   )
 
   mock_message()
-    assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E false RESULT 0)
+    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false RESULT 0)
   end_mock_message()
   assert_message(
     FATAL_ERROR
     "expected command '${CMAKE_COMMAND} -E false' to exit with status 0"
   )
 
-  assert(
-    EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
     OUTPUT "Hello.*!"
   )
 
   mock_message()
-    assert(
-      EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
       OUTPUT "Hi.*!"
     )
   end_mock_message()
@@ -206,15 +206,15 @@ function("Process execution assertions")
     "expected the output of command '${CMAKE_COMMAND} -E echo Hello world!' to match 'Hi.*!'"
   )
 
-  assert(
-    EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E invalid
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E invalid
     RESULT 1
     ERROR "CMake Error:.*Available commands:"
   )
 
   mock_message()
-    assert(
-      EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E invalid
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E invalid
       RESULT 1
       ERROR "CMake Error:.*Unavailable commands:"
     )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -9,12 +9,12 @@ function("Boolean assertions")
   mock_message()
     assert(FALSE)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected 'FALSE' to resolve to true")
+  assert_message(FATAL_ERROR "expected 'FALSE' to resolve to true")
 
   mock_message()
     assert(NOT TRUE)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected 'TRUE' to resolve to false")
+  assert_message(FATAL_ERROR "expected 'TRUE' to resolve to false")
 endfunction()
 
 function("Variable existence assertions")
@@ -27,12 +27,18 @@ function("Variable existence assertions")
   mock_message()
     assert(DEFINED NON_EXISTING_VARIABLE)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected variable 'NON_EXISTING_VARIABLE' to be defined")
+  assert_message(
+    FATAL_ERROR
+    "expected variable 'NON_EXISTING_VARIABLE' to be defined"
+  )
 
   mock_message()
     assert(NOT DEFINED EXISTING_VARIABLE)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected variable 'EXISTING_VARIABLE' not to be defined")
+  assert_message(
+    FATAL_ERROR
+    "expected variable 'EXISTING_VARIABLE' not to be defined"
+  )
 endfunction()
 
 function("Path existence assertions")
@@ -45,12 +51,12 @@ function("Path existence assertions")
   mock_message()
     assert(EXISTS non_existing_file)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected path 'non_existing_file' to exist")
+  assert_message(FATAL_ERROR "expected path 'non_existing_file' to exist")
 
   mock_message()
     assert(NOT EXISTS some_file)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected path 'some_file' not to exist")
+  assert_message(FATAL_ERROR "expected path 'some_file' not to exist")
 endfunction()
 
 function("Directory path assertions")
@@ -63,12 +69,15 @@ function("Directory path assertions")
   mock_message()
     assert(IS_DIRECTORY some_file)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected path 'some_file' to be a directory")
+  assert_message(FATAL_ERROR "expected path 'some_file' to be a directory")
 
   mock_message()
     assert(NOT IS_DIRECTORY some_directory)
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected path 'some_directory' not to be a directory")
+  assert_message(
+    FATAL_ERROR
+    "expected path 'some_directory' not to be a directory"
+  )
 endfunction()
 
 function("Regular expression match assertions")
@@ -81,12 +90,18 @@ function("Regular expression match assertions")
     mock_message()
       assert(NOT "${VALUE}" MATCHES "so.*ing")
     end_mock_message()
-    assert(MESSAGE FATAL_ERROR "expected string 'some string' not to match 'so.*ing'")
+    assert_message(
+      FATAL_ERROR
+      "expected string 'some string' not to match 'so.*ing'"
+    )
 
     mock_message()
       assert("${VALUE}" MATCHES "so.*other.*ing")
     end_mock_message()
-    assert(MESSAGE FATAL_ERROR "expected string 'some string' to match 'so.*other.*ing'")
+    assert_message(
+      FATAL_ERROR
+      "expected string 'some string' to match 'so.*other.*ing'"
+    )
   endforeach()
 endfunction()
 
@@ -107,14 +122,20 @@ function("String equality assertions")
       mock_message()
         assert("${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
       end_mock_message()
-      assert(MESSAGE FATAL_ERROR "expected string 'some string' to be equal to 'some other string'")
+      assert_message(
+        FATAL_ERROR
+        "expected string 'some string' to be equal to 'some other string'"
+      )
     endforeach()
 
     foreach(RIGHT_VALUE STRING_VAR "${STRING_VAR}")
       mock_message()
         assert(NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
       end_mock_message()
-      assert(MESSAGE FATAL_ERROR "expected string 'some string' not to be equal to 'some string'")
+      assert_message(
+        FATAL_ERROR
+        "expected string 'some string' not to be equal to 'some string'"
+      )
     endforeach()
   endforeach()
 endfunction()
@@ -132,20 +153,18 @@ function("Message assertions")
     call_sample_messages()
   end_mock_message()
 
-  assert(MESSAGE WARNING "some warning message")
-  assert(MESSAGE WARNING "some other warning message")
-  assert(MESSAGE ERROR "some error message")
-  assert(MESSAGE FATAL_ERROR "some fatal error message")
+  assert_message(WARNING "some warning message")
+  assert_message(WARNING "some other warning message")
+  assert_message(ERROR "some error message")
+  assert_message(FATAL_ERROR "some fatal error message")
 
   mock_message()
-    assert(MESSAGE ERROR "some other error message")
+    assert_message(ERROR "some other error message")
   end_mock_message()
-  assert(MESSAGE FATAL_ERROR "expected error message '' to be equal to 'some other error message'")
-
-  mock_message()
-    assert(MESSAGE SOME_MODE)
-  end_mock_message()
-  assert(MESSAGE FATAL_ERROR "usage: assert(MESSAGE <MODE> <EXPECTED_MESSAGE>)")
+  assert_message(
+    FATAL_ERROR
+    "expected error message '' to be equal to 'some other error message'"
+  )
 endfunction()
 
 function("Process execution assertions")
@@ -158,16 +177,16 @@ function("Process execution assertions")
   mock_message()
     assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E true RESULT 1)
   end_mock_message()
-  assert(
-    MESSAGE FATAL_ERROR
+  assert_message(
+    FATAL_ERROR
     "expected command '${CMAKE_COMMAND} -E true' to exit with status 1"
   )
 
   mock_message()
     assert(EXECUTE_PROCESS COMMAND "${CMAKE_COMMAND}" -E false RESULT 0)
   end_mock_message()
-  assert(
-    MESSAGE FATAL_ERROR
+  assert_message(
+    FATAL_ERROR
     "expected command '${CMAKE_COMMAND} -E false' to exit with status 0"
   )
 
@@ -182,8 +201,8 @@ function("Process execution assertions")
       OUTPUT "Hi.*!"
     )
   end_mock_message()
-  assert(
-    MESSAGE FATAL_ERROR
+  assert_message(
+    FATAL_ERROR
     "expected the output of command '${CMAKE_COMMAND} -E echo Hello world!' to match 'Hi.*!'"
   )
 
@@ -200,8 +219,8 @@ function("Process execution assertions")
       ERROR "CMake Error:.*Unavailable commands:"
     )
   end_mock_message()
-  assert(
-    MESSAGE FATAL_ERROR
+  assert_message(
+    FATAL_ERROR
     "expected the error of command '${CMAKE_COMMAND} -E invalid' to match 'CMake Error:.*Unavailable commands:'"
   )
 endfunction()


### PR DESCRIPTION
This pull request resolves #50 by separating the message and execute process assertions from the `assert` function into `assert_message` and `assert_execute_process` functions.