### PR TITLE
Modify Execute Process Result Assertion

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -130,18 +130,20 @@ function(assert_message MODE EXPECTED_MESSAGE)
   endif()
 endfunction()
 
-# Asserts whether the given command successfully executes a process.
+# Asserts whether the given command executes a process.
+#
+# This function asserts whether the given command successfully executes a
+# process. If the `ERROR` argument is specified, this function asserts
+# whether the given command fails to execute the process.
 #
 # Optional arguments:
 #   - COMMAND: The command to execute.
-#   - RESULT: If set, asserts whether the executed process exits with the given
-#     status.
 #   - OUTPUT: If set, asserts whether the output of the executed process matches
 #     the given regular expression.
 #   - ERROR: If set, asserts whether the error of the executed process matches
 #     the given regular expression.
 function(assert_execute_process)
-  cmake_parse_arguments(ARG "" "RESULT;OUTPUT;ERROR" "COMMAND" ${ARGN})
+  cmake_parse_arguments(ARG "" "OUTPUT;ERROR" "COMMAND" ${ARGN})
 
   execute_process(
     COMMAND ${ARG_COMMAND}
@@ -150,11 +152,17 @@ function(assert_execute_process)
     ERROR_VARIABLE ERR
   )
 
-  if(DEFINED ARG_RESULT AND NOT RES EQUAL "${ARG_RESULT}")
+  if(DEFINED ARG_ERROR AND RES EQUAL 0)
     string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
     message(
       FATAL_ERROR
-      "expected command '${ARG_COMMAND}' to exit with status ${ARG_RESULT}"
+      "expected command '${ARG_COMMAND}' to fail"
+    )
+  elseif(NOT DEFINED ARG_ERROR AND NOT RES EQUAL 0)
+    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
+    message(
+      FATAL_ERROR
+      "expected command '${ARG_COMMAND}' not to fail"
     )
   elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
     string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -169,25 +169,22 @@ endfunction()
 
 function("Process execution assertions")
   assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true)
-  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
-
-  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true RESULT 0)
-  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false RESULT 1)
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false ERROR .*)
 
   mock_message()
-    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true RESULT 1)
+    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true ERROR .*)
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected command '${CMAKE_COMMAND} -E true' to exit with status 1"
+    "expected command '${CMAKE_COMMAND} -E true' to fail"
   )
 
   mock_message()
-    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false RESULT 0)
+    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected command '${CMAKE_COMMAND} -E false' to exit with status 0"
+    "expected command '${CMAKE_COMMAND} -E false' not to fail"
   )
 
   assert_execute_process(
@@ -208,14 +205,12 @@ function("Process execution assertions")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E invalid
-    RESULT 1
     ERROR "CMake Error:.*Available commands:"
   )
 
   mock_message()
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E invalid
-      RESULT 1
       ERROR "CMake Error:.*Unavailable commands:"
     )
   end_mock_message()


### PR DESCRIPTION
This pull request resolves #52 by modifying the execute process result assertion. By default, the `assert_execute_process` function asserts whether the given command successfully executes a process. However, if the `ERROR` argument is specified, the function will assert whether the given command fails to execute the process.