### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -263,16 +263,23 @@ endmacro()
 # Refer to the documentation of the 'if' function for supported conditions to
 # perform the assertion.
 function(assert)
-  list(LENGTH ARGN ARGN_LENGTH)
-  if(ARGN_LENGTH GREATER 0)
-    if(COMMAND "_assert_internal_assert_${ARGN_LENGTH}")
-      cmake_language(
-        CALL "_assert_internal_assert_${ARGN_LENGTH}" ${ARGN}
-      )
-    else()
-      string(REPLACE ";" " " ARGS "${ARGN}")
-      message(FATAL_ERROR "unsupported condition: ${ARGS}")
-    endif()
+  if(ARGC EQUAL 0)
+    # Do nothing on an empty condition.
+  elseif(ARGC EQUAL 1)
+    _assert_internal_assert_1("${ARGV0}")
+  elseif(ARGC EQUAL 2)
+    _assert_internal_assert_2("${ARGV0}" "${ARGV1}")
+  elseif(ARGC EQUAL 3)
+    _assert_internal_assert_3("${ARGV0}" "${ARGV1}" "${ARGV2}")
+  elseif(ARGC EQUAL 4)
+    _assert_internal_assert_4("${ARGV0}" "${ARGV1}" "${ARGV2}" "${ARGV3}")
+  else()
+    set(ARGS "${ARGV0} ${ARGV1} ${ARGV2} ${ARGV3}")
+    math(EXPR STOP "${ARGC} - 1")
+    foreach(I RANGE 4 "${STOP}")
+      set(ARGS "${ARGS} ${ARGV${I}}")
+    endforeach()
+    message(FATAL_ERROR "unsupported condition: ${ARGS}")
   endif()
 endfunction()
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -357,7 +357,7 @@ endfunction()
 #   - ERROR: If set, asserts whether the error of the executed process matches
 #     the given regular expression.
 function(assert_execute_process)
-  cmake_parse_arguments(ARG "" "OUTPUT;ERROR" "COMMAND" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "OUTPUT;ERROR" "COMMAND")
 
   execute_process(
     COMMAND ${ARG_COMMAND}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -263,9 +263,7 @@ function("Mock message")
   end_mock_message()
 
   assert(DEFINED WARNING_MESSAGES)
-
-  set(EXPECTED_WARNING_MESSAGES "some warning message;some other warning message")
-  assert(WARNING_MESSAGES STREQUAL EXPECTED_WARNING_MESSAGES)
+  assert(WARNING_MESSAGES STREQUAL "some warning message;some other warning message")
 
   assert(DEFINED ERROR_MESSAGES)
   assert("${ERROR_MESSAGES}" STREQUAL "some error message")


### PR DESCRIPTION
This pull request resolves #57 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<index>` variables in the `assert` and `add_cmake_test` functions.
- Utilizes the `cmake_parse_arguments(PARSE_ARGV)` function in the `assert_execute_process` function.