### PR TITLE
Improve Assertion Message

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -419,28 +419,28 @@ function(assert_execute_process)
   )
 
   if(DEFINED ARG_ERROR AND RES EQUAL 0)
-    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-    message(
-      FATAL_ERROR
-      "expected command '${ARG_COMMAND}' to fail"
-    )
+    string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
+    _assert_internal_format_message(
+      MESSAGE "expected command:" "${COMMAND}" "to fail")
+    message(FATAL_ERROR "${MESSAGE}")
   elseif(NOT DEFINED ARG_ERROR AND NOT RES EQUAL 0)
-    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-    message(
-      FATAL_ERROR
-      "expected command '${ARG_COMMAND}' not to fail"
-    )
+    string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
+    _assert_internal_format_message(
+      MESSAGE "expected command:" "${COMMAND}" "not to fail")
+    message(FATAL_ERROR "${MESSAGE}")
   elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
-    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-    message(
-      FATAL_ERROR
-      "expected the output of command '${ARG_COMMAND}' to match '${ARG_OUTPUT}'"
-    )
+    string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
+    _assert_internal_format_message(
+      MESSAGE "expected the output:" "${OUT}"
+      "of command:" "${COMMAND}"
+      "to match:" "${ARG_OUTPUT}")
+    message(FATAL_ERROR "${MESSAGE}")
   elseif(DEFINED ARG_ERROR AND NOT "${ERR}" MATCHES "${ARG_ERROR}")
-    string(REPLACE ";" " " ARG_COMMAND "${ARG_COMMAND}")
-    message(
-      FATAL_ERROR
-      "expected the error of command '${ARG_COMMAND}' to match '${ARG_ERROR}'"
-    )
+    string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
+    _assert_internal_format_message(
+      MESSAGE "expected the error:" "${ERR}"
+      "of command:" "${COMMAND}"
+      "to match:" "${ARG_ERROR}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endfunction()

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -385,7 +385,10 @@ function(assert_message MODE EXPECTED_MESSAGE)
   if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
     string(TOLOWER "${MODE}" MODE)
     string(REPLACE "_" " " MODE "${MODE}")
-    message(FATAL_ERROR "expected ${MODE} message '${MESSAGE}' to be equal to '${EXPECTED_MESSAGE}'")
+    _assert_internal_format_message(
+      ASSERT_MESSAGE "expected ${MODE} message:" "${MESSAGE}"
+      "to be equal to:" "${EXPECTED_MESSAGE}")
+    message(FATAL_ERROR "${ASSERT_MESSAGE}")
   endif()
 
   if(DEFINED ${MODE}_MESSAGES)

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -20,13 +20,39 @@ function(_assert_internal_get_content VARIABLE OUTPUT_VARIABLE)
   endif()
 endfunction()
 
+# Formats an assertion message with indentation on even lines.
+#
+# Arguments:
+#   - OUT_VAR: The output variable that holds the formatted message.
+#   - FIRST_LINE: The first line of the message.
+#   - ARGN: The rest of the lines of the message.
+function(_assert_internal_format_message OUT_VAR FIRST_LINE)
+  set(MESSAGE "${FIRST_LINE}")
+  if(ARGC GREATER 2)
+    math(EXPR STOP "${ARGC} - 1")
+    foreach(I RANGE 2 "${STOP}")
+      string(STRIP "${ARGV${I}}" LINE)
+      math(EXPR MOD "${I} % 2")
+      if(MOD EQUAL 0)
+        string(REPLACE "\n" "\n  " LINE "${LINE}")
+        set(MESSAGE "${MESSAGE}\n  ${LINE}")
+      else()
+        set(MESSAGE "${MESSAGE}\n${LINE}")
+      endif()
+    endforeach()
+  endif()
+  set("${OUT_VAR}" "${MESSAGE}" PARENT_SCOPE)
+endfunction()
+
 # Asserts whether the given variable is defined.
 #
 # Arguments:
 #   - VARIABLE: The variable to check.
 macro(_assert_internal_assert_2_defined VARIABLE)
   if(NOT DEFINED "${VARIABLE}")
-    message(FATAL_ERROR "expected variable:\n  ${VARIABLE}\nto be defined")
+    _assert_internal_format_message(
+      MESSAGE "expected variable:" "${VARIABLE}" "to be defined")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -36,7 +62,9 @@ endmacro()
 #   - VARIABLE: The variable to check.
 macro(_assert_internal_assert_2_not_defined VARIABLE)
   if(DEFINED "${VARIABLE}")
-    message(FATAL_ERROR "expected variable:\n  ${VARIABLE}\nnot to be defined")
+    _assert_internal_format_message(
+      MESSAGE "expected variable:" "${VARIABLE}" "not to be defined")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -46,7 +74,9 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_exists PATH)
   if(NOT EXISTS "${PATH}")
-    message(FATAL_ERROR "expected path:\n  ${PATH}\nto exist")
+    _assert_internal_format_message(
+      MESSAGE "expected path:" "${PATH}" "to exist")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -56,7 +86,9 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_not_exists PATH)
   if(EXISTS "${PATH}")
-    message(FATAL_ERROR "expected path:\n  ${PATH}\nnot to exist")
+    _assert_internal_format_message(
+      MESSAGE "expected path:" "${PATH}" "not to exist")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -66,7 +98,9 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_is_directory PATH)
   if(NOT IS_DIRECTORY "${PATH}")
-    message(FATAL_ERROR "expected path:\n  ${PATH}\nto be a directory")
+    _assert_internal_format_message(
+      MESSAGE "expected path:" "${PATH}" "to be a directory")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -76,7 +110,9 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_not_is_directory PATH)
   if(IS_DIRECTORY "${PATH}")
-    message(FATAL_ERROR "expected path:\n  ${PATH}\nnot to be a directory")
+    _assert_internal_format_message(
+      MESSAGE "expected path:" "${PATH}" "not to be a directory")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -88,10 +124,9 @@ endmacro()
 macro(_assert_internal_assert_3_matches STRING REGEX)
   _assert_internal_get_content("${STRING}" STRING_CONTENT)
   if(NOT "${STRING_CONTENT}" MATCHES "${REGEX}")
-    message(
-      FATAL_ERROR
-      "expected string:\n  ${STRING_CONTENT}\nto match:\n  ${REGEX}"
-    )
+    _assert_internal_format_message(
+      MESSAGE "expected string:" "${STRING_CONTENT}" "to match:" "${REGEX}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -103,10 +138,9 @@ endmacro()
 macro(_assert_internal_assert_3_not_matches STRING REGEX)
   _assert_internal_get_content("${STRING}" STRING_CONTENT)
   if("${STRING_CONTENT}" MATCHES "${REGEX}")
-    message(
-      FATAL_ERROR
-      "expected string:\n  ${STRING_CONTENT}\nnot to match:\n  ${REGEX}"
-    )
+    _assert_internal_format_message(
+      MESSAGE "expected string:" "${STRING_CONTENT}" "not to match:" "${REGEX}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -119,10 +153,10 @@ macro(_assert_internal_assert_3_strequal STRING1 STRING2)
   _assert_internal_get_content("${STRING1}" STRING1_CONTENT)
   _assert_internal_get_content("${STRING2}" STRING2_CONTENT)
   if(NOT "${STRING1_CONTENT}" STREQUAL "${STRING2_CONTENT}")
-    message(
-      FATAL_ERROR
-      "expected string:\n  ${STRING1_CONTENT}\nto be equal to:\n  ${STRING2_CONTENT}"
-    )
+    _assert_internal_format_message(
+      MESSAGE "expected string:" "${STRING1_CONTENT}"
+      "to be equal to:" "${STRING2_CONTENT}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -135,10 +169,10 @@ macro(_assert_internal_assert_3_not_strequal STRING1 STRING2)
   _assert_internal_get_content("${STRING1}" STRING1_CONTENT)
   _assert_internal_get_content("${STRING2}" STRING2_CONTENT)
   if("${STRING1_CONTENT}" STREQUAL "${STRING2_CONTENT}")
-    message(
-      FATAL_ERROR
-      "expected string:\n  ${STRING1_CONTENT}\nnot to be equal to:\n  ${STRING2_CONTENT}"
-    )
+    _assert_internal_format_message(
+      MESSAGE "expected string:" "${STRING1_CONTENT}"
+      "not to be equal to:" "${STRING2_CONTENT}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -151,7 +185,9 @@ macro(_assert_internal_assert_1 ARG0)
     # Do nothing on an empty condition.
   else()
     if(NOT "${ARG0}")
-      message(FATAL_ERROR "expected:\n  ${ARG0}\nto resolve to true")
+      _assert_internal_format_message(
+        MESSAGE "expected:" "${ARG0}" "to resolve to true")
+      message(FATAL_ERROR "${MESSAGE}")
     endif()
   endif()
 endmacro()
@@ -162,7 +198,9 @@ endmacro()
 #   - ARG0: The first argument.
 macro(_assert_internal_assert_1_not ARG0)
   if("${ARG0}")
-    message(FATAL_ERROR "expected:\n  ${ARG0}\nto resolve to false")
+    _assert_internal_format_message(
+      MESSAGE "expected:" "${ARG0}" "to resolve to false")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -181,7 +219,9 @@ macro(_assert_internal_assert_2 ARG0 ARG1)
         CALL "_assert_internal_assert_2_${OPERATOR}" "${ARG1}"
       )
     else()
-      message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1}")
+      _assert_internal_format_message(
+        MESSAGE "unsupported condition:" "${ARG0} ${ARG1}")
+      message(FATAL_ERROR "${MESSAGE}")
     endif()
   endif()
 endmacro()
@@ -198,7 +238,9 @@ macro(_assert_internal_assert_2_not ARG0 ARG1)
       CALL "_assert_internal_assert_2_not_${OPERATOR}" "${ARG1}"
     )
   else()
-    message(FATAL_ERROR "unsupported condition:\n  NOT ${ARG0} ${ARG1}")
+    _assert_internal_format_message(
+      MESSAGE "unsupported condition:" "NOT ${ARG0} ${ARG1}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -218,7 +260,9 @@ macro(_assert_internal_assert_3 ARG0 ARG1 ARG2)
         CALL "_assert_internal_assert_3_${OPERATOR}" "${ARG0}" "${ARG2}"
       )
     else()
-      message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1} ${ARG2}")
+      _assert_internal_format_message(
+        MESSAGE "unsupported condition:" "${ARG0} ${ARG1} ${ARG2}")
+      message(FATAL_ERROR "${MESSAGE}")
     endif()
   endif()
 endmacro()
@@ -236,7 +280,9 @@ macro(_assert_internal_assert_3_not ARG0 ARG1 ARG2)
       CALL "_assert_internal_assert_3_not_${OPERATOR}" "${ARG0}" "${ARG2}"
     )
   else()
-    message(FATAL_ERROR "unsupported condition:\n  NOT ${ARG0} ${ARG1} ${ARG2}")
+    _assert_internal_format_message(
+      MESSAGE "unsupported condition:" "NOT ${ARG0} ${ARG1} ${ARG2}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -251,7 +297,9 @@ macro(_assert_internal_assert_4 ARG0 ARG1 ARG2 ARG3)
   if("${ARG0}" STREQUAL NOT)
     _assert_internal_assert_3_not("${ARG1}" "${ARG2}" "${ARG3}")
   else()
-    message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1} ${ARG2} ${ARG3}")
+    _assert_internal_format_message(
+      MESSAGE "unsupported condition:" "${ARG0} ${ARG1} ${ARG2} ${ARG3}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endmacro()
 
@@ -279,7 +327,8 @@ function(assert)
     foreach(I RANGE 4 "${STOP}")
       set(ARGS "${ARGS} ${ARGV${I}}")
     endforeach()
-    message(FATAL_ERROR "unsupported condition:\n  ${ARGS}")
+    _assert_internal_format_message(MESSAGE "unsupported condition:" "${ARGS}")
+    message(FATAL_ERROR "${MESSAGE}")
   endif()
 endfunction()
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -26,7 +26,7 @@ endfunction()
 #   - VARIABLE: The variable to check.
 macro(_assert_internal_assert_2_defined VARIABLE)
   if(NOT DEFINED "${VARIABLE}")
-    message(FATAL_ERROR "expected variable '${VARIABLE}' to be defined")
+    message(FATAL_ERROR "expected variable:\n  ${VARIABLE}\nto be defined")
   endif()
 endmacro()
 
@@ -36,7 +36,7 @@ endmacro()
 #   - VARIABLE: The variable to check.
 macro(_assert_internal_assert_2_not_defined VARIABLE)
   if(DEFINED "${VARIABLE}")
-    message(FATAL_ERROR "expected variable '${VARIABLE}' not to be defined")
+    message(FATAL_ERROR "expected variable:\n  ${VARIABLE}\nnot to be defined")
   endif()
 endmacro()
 
@@ -46,7 +46,7 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_exists PATH)
   if(NOT EXISTS "${PATH}")
-    message(FATAL_ERROR "expected path '${PATH}' to exist")
+    message(FATAL_ERROR "expected path:\n  ${PATH}\nto exist")
   endif()
 endmacro()
 
@@ -56,7 +56,7 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_not_exists PATH)
   if(EXISTS "${PATH}")
-    message(FATAL_ERROR "expected path '${PATH}' not to exist")
+    message(FATAL_ERROR "expected path:\n  ${PATH}\nnot to exist")
   endif()
 endmacro()
 
@@ -66,7 +66,7 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_is_directory PATH)
   if(NOT IS_DIRECTORY "${PATH}")
-    message(FATAL_ERROR "expected path '${PATH}' to be a directory")
+    message(FATAL_ERROR "expected path:\n  ${PATH}\nto be a directory")
   endif()
 endmacro()
 
@@ -76,7 +76,7 @@ endmacro()
 #   - PATH: The path to check.
 macro(_assert_internal_assert_2_not_is_directory PATH)
   if(IS_DIRECTORY "${PATH}")
-    message(FATAL_ERROR "expected path '${PATH}' not to be a directory")
+    message(FATAL_ERROR "expected path:\n  ${PATH}\nnot to be a directory")
   endif()
 endmacro()
 
@@ -90,7 +90,7 @@ macro(_assert_internal_assert_3_matches STRING REGEX)
   if(NOT "${STRING_CONTENT}" MATCHES "${REGEX}")
     message(
       FATAL_ERROR
-      "expected string '${STRING_CONTENT}' to match '${REGEX}'"
+      "expected string:\n  ${STRING_CONTENT}\nto match:\n  ${REGEX}"
     )
   endif()
 endmacro()
@@ -105,7 +105,7 @@ macro(_assert_internal_assert_3_not_matches STRING REGEX)
   if("${STRING_CONTENT}" MATCHES "${REGEX}")
     message(
       FATAL_ERROR
-      "expected string '${STRING_CONTENT}' not to match '${REGEX}'"
+      "expected string:\n  ${STRING_CONTENT}\nnot to match:\n  ${REGEX}"
     )
   endif()
 endmacro()
@@ -121,7 +121,7 @@ macro(_assert_internal_assert_3_strequal STRING1 STRING2)
   if(NOT "${STRING1_CONTENT}" STREQUAL "${STRING2_CONTENT}")
     message(
       FATAL_ERROR
-      "expected string '${STRING1_CONTENT}' to be equal to '${STRING2_CONTENT}'"
+      "expected string:\n  ${STRING1_CONTENT}\nto be equal to:\n  ${STRING2_CONTENT}"
     )
   endif()
 endmacro()
@@ -137,7 +137,7 @@ macro(_assert_internal_assert_3_not_strequal STRING1 STRING2)
   if("${STRING1_CONTENT}" STREQUAL "${STRING2_CONTENT}")
     message(
       FATAL_ERROR
-      "expected string '${STRING1_CONTENT}' not to be equal to '${STRING2_CONTENT}'"
+      "expected string:\n  ${STRING1_CONTENT}\nnot to be equal to:\n  ${STRING2_CONTENT}"
     )
   endif()
 endmacro()
@@ -151,7 +151,7 @@ macro(_assert_internal_assert_1 ARG0)
     # Do nothing on an empty condition.
   else()
     if(NOT "${ARG0}")
-      message(FATAL_ERROR "expected '${ARG0}' to resolve to true")
+      message(FATAL_ERROR "expected:\n  ${ARG0}\nto resolve to true")
     endif()
   endif()
 endmacro()
@@ -162,7 +162,7 @@ endmacro()
 #   - ARG0: The first argument.
 macro(_assert_internal_assert_1_not ARG0)
   if("${ARG0}")
-    message(FATAL_ERROR "expected '${ARG0}' to resolve to false")
+    message(FATAL_ERROR "expected:\n  ${ARG0}\nto resolve to false")
   endif()
 endmacro()
 
@@ -181,7 +181,7 @@ macro(_assert_internal_assert_2 ARG0 ARG1)
         CALL "_assert_internal_assert_2_${OPERATOR}" "${ARG1}"
       )
     else()
-      message(FATAL_ERROR "unsupported condition: ${ARG0} ${ARG1}")
+      message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1}")
     endif()
   endif()
 endmacro()
@@ -198,7 +198,7 @@ macro(_assert_internal_assert_2_not ARG0 ARG1)
       CALL "_assert_internal_assert_2_not_${OPERATOR}" "${ARG1}"
     )
   else()
-    message(FATAL_ERROR "unsupported condition: NOT ${ARG0} ${ARG1}")
+    message(FATAL_ERROR "unsupported condition:\n  NOT ${ARG0} ${ARG1}")
   endif()
 endmacro()
 
@@ -218,7 +218,7 @@ macro(_assert_internal_assert_3 ARG0 ARG1 ARG2)
         CALL "_assert_internal_assert_3_${OPERATOR}" "${ARG0}" "${ARG2}"
       )
     else()
-      message(FATAL_ERROR "unsupported condition: ${ARG0} ${ARG1} ${ARG2}")
+      message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1} ${ARG2}")
     endif()
   endif()
 endmacro()
@@ -236,7 +236,7 @@ macro(_assert_internal_assert_3_not ARG0 ARG1 ARG2)
       CALL "_assert_internal_assert_3_not_${OPERATOR}" "${ARG0}" "${ARG2}"
     )
   else()
-    message(FATAL_ERROR "unsupported condition: NOT ${ARG0} ${ARG1} ${ARG2}")
+    message(FATAL_ERROR "unsupported condition:\n  NOT ${ARG0} ${ARG1} ${ARG2}")
   endif()
 endmacro()
 
@@ -251,7 +251,7 @@ macro(_assert_internal_assert_4 ARG0 ARG1 ARG2 ARG3)
   if("${ARG0}" STREQUAL NOT)
     _assert_internal_assert_3_not("${ARG1}" "${ARG2}" "${ARG3}")
   else()
-    message(FATAL_ERROR "unsupported condition: ${ARG0} ${ARG1} ${ARG2} ${ARG3}")
+    message(FATAL_ERROR "unsupported condition:\n  ${ARG0} ${ARG1} ${ARG2} ${ARG3}")
   endif()
 endmacro()
 
@@ -279,7 +279,7 @@ function(assert)
     foreach(I RANGE 4 "${STOP}")
       set(ARGS "${ARGS} ${ARGV${I}}")
     endforeach()
-    message(FATAL_ERROR "unsupported condition: ${ARGS}")
+    message(FATAL_ERROR "unsupported condition:\n  ${ARGS}")
   endif()
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ endfunction()
 add_cmake_test(
   cmake/InternalTest.cmake
   "Variable content retrieval"
+  "Assertion message formatting"
 )
 
 add_cmake_test(

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -213,48 +213,52 @@ function("Process execution assertions")
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected command '${CMAKE_COMMAND} -E true' to fail"
-  )
+    "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
 
   mock_message()
     assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected command '${CMAKE_COMMAND} -E false' not to fail"
-  )
+    "expected command:\n  ${CMAKE_COMMAND} -E false\nnot to fail")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-    OUTPUT "Hello.*!"
-  )
+    OUTPUT "Hello.*!")
 
   mock_message()
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-      OUTPUT "Hi.*!"
-    )
+      OUTPUT "Hi.*!")
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
-    "expected the output of command '${CMAKE_COMMAND} -E echo Hello world!' to match 'Hi.*!'"
-  )
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected the output:"
+    "  Hello world!"
+    "of command:"
+    "  ${CMAKE_COMMAND} -E echo Hello world!"
+    "to match:"
+    "  Hi.*!")
+  assert_message(FATAL_ERROR "${EXPECTED_MESSAGE}")
 
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" -E invalid
-    ERROR "CMake Error:.*Available commands:"
-  )
+    COMMAND "${CMAKE_COMMAND}" -E touch /
+    ERROR "cmake -E touch: failed to update")
 
   mock_message()
     assert_execute_process(
-      COMMAND "${CMAKE_COMMAND}" -E invalid
-      ERROR "CMake Error:.*Unavailable commands:"
-    )
+      COMMAND "${CMAKE_COMMAND}" -E touch /
+      ERROR "cmake -E touch: not failed to update")
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
-    "expected the error of command '${CMAKE_COMMAND} -E invalid' to match 'CMake Error:.*Unavailable commands:'"
-  )
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected the error:"
+    "  cmake -E touch: failed to update \"/\"."
+    "of command:"
+    "  ${CMAKE_COMMAND} -E touch /"
+    "to match:"
+    "  cmake -E touch: not failed to update")
+  assert_message(FATAL_ERROR "${EXPECTED_MESSAGE}")
 endfunction()
 
 function("Mock message")

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -14,12 +14,12 @@ function("Boolean assertions")
   mock_message()
     assert(FALSE)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected 'FALSE' to resolve to true")
+  assert_message(FATAL_ERROR "expected:\n  FALSE\nto resolve to true")
 
   mock_message()
     assert(NOT TRUE)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected 'TRUE' to resolve to false")
+  assert_message(FATAL_ERROR "expected:\n  TRUE\nto resolve to false")
 endfunction()
 
 function("Variable existence assertions")
@@ -34,7 +34,7 @@ function("Variable existence assertions")
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected variable 'NON_EXISTING_VARIABLE' to be defined"
+    "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined"
   )
 
   mock_message()
@@ -42,7 +42,7 @@ function("Variable existence assertions")
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected variable 'EXISTING_VARIABLE' not to be defined"
+    "expected variable:\n  EXISTING_VARIABLE\nnot to be defined"
   )
 endfunction()
 
@@ -56,12 +56,12 @@ function("Path existence assertions")
   mock_message()
     assert(EXISTS non_existing_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path 'non_existing_file' to exist")
+  assert_message(FATAL_ERROR "expected path:\n  non_existing_file\nto exist")
 
   mock_message()
     assert(NOT EXISTS some_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path 'some_file' not to exist")
+  assert_message(FATAL_ERROR "expected path:\n  some_file\nnot to exist")
 endfunction()
 
 function("Directory path assertions")
@@ -74,14 +74,14 @@ function("Directory path assertions")
   mock_message()
     assert(IS_DIRECTORY some_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path 'some_file' to be a directory")
+  assert_message(FATAL_ERROR "expected path:\n  some_file\nto be a directory")
 
   mock_message()
     assert(NOT IS_DIRECTORY some_directory)
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected path 'some_directory' not to be a directory"
+    "expected path:\n  some_directory\nnot to be a directory"
   )
 endfunction()
 
@@ -97,7 +97,7 @@ function("Regular expression match assertions")
     end_mock_message()
     assert_message(
       FATAL_ERROR
-      "expected string 'some string' not to match 'so.*ing'"
+      "expected string:\n  some string\nnot to match:\n  so.*ing"
     )
 
     mock_message()
@@ -105,7 +105,7 @@ function("Regular expression match assertions")
     end_mock_message()
     assert_message(
       FATAL_ERROR
-      "expected string 'some string' to match 'so.*other.*ing'"
+      "expected string:\n  some string\nto match:\n  so.*other.*ing"
     )
   endforeach()
 endfunction()
@@ -129,7 +129,7 @@ function("String equality assertions")
       end_mock_message()
       assert_message(
         FATAL_ERROR
-        "expected string 'some string' to be equal to 'some other string'"
+        "expected string:\n  some string\nto be equal to:\n  some other string"
       )
     endforeach()
 
@@ -139,7 +139,7 @@ function("String equality assertions")
       end_mock_message()
       assert_message(
         FATAL_ERROR
-        "expected string 'some string' not to be equal to 'some string'"
+        "expected string:\n  some string\nnot to be equal to:\n  some string"
       )
     endforeach()
   endforeach()
@@ -149,32 +149,32 @@ function("Unsupported assertions")
   mock_message()
     assert(first second)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: first second")
+  assert_message(FATAL_ERROR "unsupported condition:\n  first second")
 
   mock_message()
     assert(first second third)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: first second third")
+  assert_message(FATAL_ERROR "unsupported condition:\n  first second third")
 
   mock_message()
     assert(first second third fourth)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: first second third fourth")
+  assert_message(FATAL_ERROR "unsupported condition:\n  first second third fourth")
 
   mock_message()
     assert(NOT first second)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: NOT first second")
+  assert_message(FATAL_ERROR "unsupported condition:\n  NOT first second")
 
   mock_message()
     assert(NOT first second third)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: NOT first second third")
+  assert_message(FATAL_ERROR "unsupported condition:\n  NOT first second third")
 
   mock_message()
     assert(NOT first second third fourth)
   end_mock_message()
-  assert_message(FATAL_ERROR "unsupported condition: NOT first second third fourth")
+  assert_message(FATAL_ERROR "unsupported condition:\n  NOT first second third fourth")
 endfunction()
 
 function(call_sample_messages)

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -200,7 +200,7 @@ function("Message assertions")
   end_mock_message()
   assert_message(
     FATAL_ERROR
-    "expected error message '' to be equal to 'some other error message'"
+    "expected error message:\n  \nto be equal to:\n  some other error message"
   )
 endfunction()
 

--- a/test/cmake/InternalTest.cmake
+++ b/test/cmake/InternalTest.cmake
@@ -11,4 +11,19 @@ function("Variable content retrieval")
   assert(CONTENT STREQUAL "some other value")
 endfunction()
 
+function("Assertion message formatting")
+  _assert_internal_format_message(
+    MESSAGE "first line" "second line" "third line\nthird line" "fourth line\nfourth line")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "first line"
+    "  second line"
+    "third line"
+    "third line"
+    "  fourth line"
+    "  fourth line")
+  assert(MESSAGE STREQUAL EXPECTED_MESSAGE)
+endfunction()
+
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #63 by improving the assertion messages in the `assert`, `assert_message`, and `assert_execute_process` functions. This change also adds a new `_assert_internal_format_message` internal function for formatting the assertion messages.