### PR TITLE
Modify Message Assertion to Only Assert Fatal Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 
 project(
   Assertion
-  VERSION 0.2.0
+  VERSION 0.3.0
   DESCRIPTION "A collection of assertion functions for testing purposes"
   HOMEPAGE_URL https://github.com/threeal/assertion-cmake
   LANGUAGES NONE

--- a/README.md
+++ b/README.md
@@ -51,18 +51,20 @@ assert(EXISTS some_file)
 assert(NOT DIRECTORY some_file)
 ```
 
-### Mock and Assert Messages
+### Mock Messages and Assert Fatal Errors
 
-Use the `mock_message` function to mock the `message` function, allowing assertions on the `message` function as shown in the following example:
+Use the `mock_message` function to mock the `message` function, allowing assertions on the fatal error messages as shown in the following example:
 
 ```cmake
+function(some_function)
+  message(FATAL_ERROR "some fatal error message")
+endfunction()
+
 mock_message()
-  message(STATUS "some status message")
-  message(ERROR "some error message")
+  some_function()
 end_mock_message()
 
-assert_message(STATUS "some status message")
-assert_message(ERROR "some error message")
+assert_fatal_error("some fatal error message")
 ```
 
 ### Assert Process Execution

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ This module can be integrated into a CMake project in the following ways:
 - Use [`file(DOWNLOAD)`](https://cmake.org/cmake/help/latest/command/file.html#download) to automatically download the `Assertion.cmake` file:
   ```cmake
   file(
-    DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+    DOWNLOAD https://threeal.github.io/assertion-cmake/v0.3.0
     ${CMAKE_BINARY_DIR}/Assertion.cmake
   )
   include(${CMAKE_BINARY_DIR}/Assertion.cmake)
   ```
 - Use [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to add this package to the CMake project:
   ```cmake
-  cpmaddpackage(gh:threeal/assertion-cmake@0.2.0)
+  cpmaddpackage(gh:threeal/assertion-cmake@0.3.0)
   include(${Assertion_SOURCE_DIR}/cmake/Assertion.cmake)
   ```
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -157,30 +157,24 @@ function(end_mock_message)
   set_property(GLOBAL PROPERTY message_mocked OFF)
 endfunction()
 
-# Asserts whether the 'message' function was called with the expected arguments.
+# Asserts whether a fatal error was received with the expected message.
 #
-# This function asserts whether a message with the specified mode was called
-# with the expected message content.
-#
-# This function can only assert calls to the mocked 'message' function, which is
-# enabled by calling the 'mock_message' function.
+# This function can only assert a fatal error sent from the mocked 'message'
+# function, which is enabled by calling the 'mock_message' function.
 #
 # Arguments:
-#   - MODE: The message mode.
-#   - EXPECTED_MESSAGE: The expected message content.
-function(assert_message MODE EXPECTED_MESSAGE)
-  list(POP_FRONT ${MODE}_MESSAGES MESSAGE)
+#   - EXPECTED_MESSAGE: The expected fatal error message.
+function(assert_fatal_error EXPECTED_MESSAGE)
+  list(POP_FRONT FATAL_ERROR_MESSAGES MESSAGE)
   if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
-    string(TOLOWER "${MODE}" MODE)
-    string(REPLACE "_" " " MODE "${MODE}")
     _assert_internal_format_message(
-      ASSERT_MESSAGE "expected ${MODE} message:" "${MESSAGE}"
+      ASSERT_MESSAGE "expected fatal error message:" "${MESSAGE}"
       "to be equal to:" "${EXPECTED_MESSAGE}")
     message(FATAL_ERROR "${ASSERT_MESSAGE}")
   endif()
 
-  if(DEFINED ${MODE}_MESSAGES)
-    set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
+  if(DEFINED FATAL_ERROR_MESSAGES)
+    set(FATAL_ERROR_MESSAGES "${FATAL_ERROR_MESSAGES}" PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,7 @@ add_cmake_test(
   "Directory path assertions"
   "Regular expression match assertions"
   "String equality assertions"
-  "Message assertions"
+  "Fatal error assertions"
   "Process execution assertions"
   "Mock message"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -9,12 +9,12 @@ function("Boolean assertions")
   mock_message()
     assert(FALSE)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected:\n  FALSE\nto resolve to true")
+  assert_fatal_error("expected:\n  FALSE\nto resolve to true")
 
   mock_message()
     assert(NOT TRUE)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected:\n  NOT TRUE\nto resolve to true")
+  assert_fatal_error("expected:\n  NOT TRUE\nto resolve to true")
 endfunction()
 
 function("Variable existence assertions")
@@ -27,16 +27,14 @@ function("Variable existence assertions")
   mock_message()
     assert(DEFINED NON_EXISTING_VARIABLE)
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
+  assert_fatal_error(
     "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined"
   )
 
   mock_message()
     assert(NOT DEFINED EXISTING_VARIABLE)
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
+  assert_fatal_error(
     "expected variable:\n  EXISTING_VARIABLE\nnot to be defined"
   )
 endfunction()
@@ -51,12 +49,12 @@ function("Path existence assertions")
   mock_message()
     assert(EXISTS non_existing_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path:\n  non_existing_file\nto exist")
+  assert_fatal_error("expected path:\n  non_existing_file\nto exist")
 
   mock_message()
     assert(NOT EXISTS some_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path:\n  some_file\nnot to exist")
+  assert_fatal_error("expected path:\n  some_file\nnot to exist")
 endfunction()
 
 function("Directory path assertions")
@@ -69,15 +67,12 @@ function("Directory path assertions")
   mock_message()
     assert(IS_DIRECTORY some_file)
   end_mock_message()
-  assert_message(FATAL_ERROR "expected path:\n  some_file\nto be a directory")
+  assert_fatal_error("expected path:\n  some_file\nto be a directory")
 
   mock_message()
     assert(NOT IS_DIRECTORY some_directory)
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
-    "expected path:\n  some_directory\nnot to be a directory"
-  )
+  assert_fatal_error("expected path:\n  some_directory\nnot to be a directory")
 endfunction()
 
 function("Regular expression match assertions")
@@ -90,16 +85,14 @@ function("Regular expression match assertions")
     mock_message()
       assert(NOT "${VALUE}" MATCHES "so.*ing")
     end_mock_message()
-    assert_message(
-      FATAL_ERROR
+    assert_fatal_error(
       "expected string:\n  some string\nnot to match:\n  so.*ing"
     )
 
     mock_message()
       assert("${VALUE}" MATCHES "so.*other.*ing")
     end_mock_message()
-    assert_message(
-      FATAL_ERROR
+    assert_fatal_error(
       "expected string:\n  some string\nto match:\n  so.*other.*ing"
     )
   endforeach()
@@ -122,8 +115,7 @@ function("String equality assertions")
       mock_message()
         assert("${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
       end_mock_message()
-      assert_message(
-        FATAL_ERROR
+      assert_fatal_error(
         "expected string:\n  some string\nto be equal to:\n  some other string"
       )
     endforeach()
@@ -132,8 +124,7 @@ function("String equality assertions")
       mock_message()
         assert(NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
       end_mock_message()
-      assert_message(
-        FATAL_ERROR
+      assert_fatal_error(
         "expected string:\n  some string\nnot to be equal to:\n  some string"
       )
     endforeach()
@@ -148,23 +139,27 @@ function(call_sample_messages)
   message(ERROR "some other error message")
 endfunction()
 
-function("Message assertions")
-  mock_message()
-    call_sample_messages()
-  end_mock_message()
-
-  assert_message(WARNING "some warning message")
-  assert_message(WARNING "some other warning message")
-  assert_message(ERROR "some error message")
-  assert_message(FATAL_ERROR "some fatal error message")
+function("Fatal error assertions")
+  function(some_function)
+    message(FATAL_ERROR "some fatal error message")
+  endfunction()
 
   mock_message()
-    assert_message(ERROR "some other error message")
+    some_function()
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
-    "expected error message:\n  \nto be equal to:\n  some other error message"
-  )
+  assert_fatal_error("some fatal error message")
+
+  mock_message()
+    some_function()
+    assert_fatal_error("some other fatal error message")
+  end_mock_message()
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected fatal error message:"
+    "  some fatal error message"
+    "to be equal to:"
+    "  some other fatal error message")
+  assert_fatal_error("${EXPECTED_MESSAGE}")
 endfunction()
 
 function("Process execution assertions")
@@ -174,15 +169,13 @@ function("Process execution assertions")
   mock_message()
     assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true ERROR .*)
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
+  assert_fatal_error(
     "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
 
   mock_message()
     assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
   end_mock_message()
-  assert_message(
-    FATAL_ERROR
+  assert_fatal_error(
     "expected command:\n  ${CMAKE_COMMAND} -E false\nnot to fail")
 
   assert_execute_process(
@@ -202,7 +195,7 @@ function("Process execution assertions")
     "  ${CMAKE_COMMAND} -E echo Hello world!"
     "to match:"
     "  Hi.*!")
-  assert_message(FATAL_ERROR "${EXPECTED_MESSAGE}")
+  assert_fatal_error("${EXPECTED_MESSAGE}")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E touch /
@@ -221,7 +214,7 @@ function("Process execution assertions")
     "  ${CMAKE_COMMAND} -E touch /"
     "to match:"
     "  cmake -E touch: not failed to update")
-  assert_message(FATAL_ERROR "${EXPECTED_MESSAGE}")
+  assert_fatal_error("${EXPECTED_MESSAGE}")
 endfunction()
 
 function("Mock message")


### PR DESCRIPTION
This pull request resolves #70 by introducing the following changes:
- Modifies the `assert_message` function to the `assert_fatal_error` function, which specifically asserts only fatal error messages.
- Updates the message assertion usage in the `README.md` file.
- Bumps the project version to 0.3.0.