### PR TITLE
Modify Assert Fatal Error Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [CMake](https://cmake.org/) module containing a collection of assertion functi
 ## Key Features
 
 - Contains a collection of assertion functions for testing purposes.
-- Supports mocking and asserting the `message` function.
+- Supports asserting fatal error messages.
 - Supports asserting process execution.
 
 ## Integration
@@ -51,20 +51,16 @@ assert(EXISTS some_file)
 assert(NOT DIRECTORY some_file)
 ```
 
-### Mock Messages and Assert Fatal Errors
+### Assert Fatal Errors
 
-Use the `mock_message` function to mock the `message` function, allowing assertions on the fatal error messages as shown in the following example:
+Use the `assert_fatal_error` function to assert whether a call to the given function or macro throws the expected fatal error message:
 
 ```cmake
 function(some_function)
   message(FATAL_ERROR "some fatal error message")
 endfunction()
 
-mock_message()
-  some_function()
-end_mock_message()
-
-assert_fatal_error("some fatal error message")
+assert_fatal_error(CALL some_function MESSAGE "some fatal error message")
 ```
 
 ### Assert Process Execution

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -163,24 +163,28 @@ macro(end_mock_message)
   endif()
 endmacro()
 
-# Asserts whether a fatal error was received with the expected message.
+# Asserts whether a command call throws a fatal error message.
 #
-# This function can only assert a fatal error sent from the mocked 'message'
-# function, which is enabled by calling the 'mock_message' function.
+# ```cmake
+# assert_fatal_error(CALL <command> [<arg>...] MESSAGE <message>)
+# ```
 #
-# Arguments:
-#   - EXPECTED_MESSAGE: The expected fatal error message.
-function(assert_fatal_error EXPECTED_MESSAGE)
+# Asserts whether a command named `<command>` called with the specified
+# arguments throws the expected `<message>` fatal error message.
+function(assert_fatal_error)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" MESSAGE CALL)
+
+  list(POP_FRONT ARG_CALL COMMAND)
+  mock_message()
+    cmake_language(CALL "${COMMAND}" ${ARG_CALL})
+  end_mock_message()
+
   list(POP_FRONT FATAL_ERROR_MESSAGES MESSAGE)
-  if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
+  if(NOT MESSAGE STREQUAL ARG_MESSAGE)
     _assert_internal_format_message(
       ASSERT_MESSAGE "expected fatal error message:" "${MESSAGE}"
-      "to be equal to:" "${EXPECTED_MESSAGE}")
+      "to be equal to:" "${ARG_MESSAGE}")
     message(FATAL_ERROR "${ASSERT_MESSAGE}")
-  endif()
-
-  if(DEFINED FATAL_ERROR_MESSAGES)
-    set(FATAL_ERROR_MESSAGES "${FATAL_ERROR_MESSAGES}" PARENT_SCOPE)
   endif()
 endfunction()
 

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -6,15 +6,13 @@ function("Boolean assertions")
   assert(TRUE)
   assert(NOT FALSE)
 
-  mock_message()
-    assert(FALSE)
-  end_mock_message()
-  assert_fatal_error("expected:\n  FALSE\nto resolve to true")
+  assert_fatal_error(
+    CALL assert FALSE
+    MESSAGE "expected:\n  FALSE\nto resolve to true")
 
-  mock_message()
-    assert(NOT TRUE)
-  end_mock_message()
-  assert_fatal_error("expected:\n  NOT TRUE\nto resolve to true")
+  assert_fatal_error(
+    CALL assert NOT TRUE
+    MESSAGE "expected:\n  NOT TRUE\nto resolve to true")
 endfunction()
 
 function("Variable existence assertions")
@@ -24,19 +22,13 @@ function("Variable existence assertions")
   assert(DEFINED EXISTING_VARIABLE)
   assert(NOT DEFINED NON_EXSITING_VARIABLE)
 
-  mock_message()
-    assert(DEFINED NON_EXISTING_VARIABLE)
-  end_mock_message()
   assert_fatal_error(
-    "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined"
-  )
+    CALL assert DEFINED NON_EXISTING_VARIABLE
+    MESSAGE "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined")
 
-  mock_message()
-    assert(NOT DEFINED EXISTING_VARIABLE)
-  end_mock_message()
   assert_fatal_error(
-    "expected variable:\n  EXISTING_VARIABLE\nnot to be defined"
-  )
+    CALL assert NOT DEFINED EXISTING_VARIABLE
+    MESSAGE "expected variable:\n  EXISTING_VARIABLE\nnot to be defined")
 endfunction()
 
 function("Path existence assertions")
@@ -46,15 +38,13 @@ function("Path existence assertions")
   assert(EXISTS some_file)
   assert(NOT EXISTS non_existing_file)
 
-  mock_message()
-    assert(EXISTS non_existing_file)
-  end_mock_message()
-  assert_fatal_error("expected path:\n  non_existing_file\nto exist")
+  assert_fatal_error(
+    CALL assert EXISTS non_existing_file
+    MESSAGE "expected path:\n  non_existing_file\nto exist")
 
-  mock_message()
-    assert(NOT EXISTS some_file)
-  end_mock_message()
-  assert_fatal_error("expected path:\n  some_file\nnot to exist")
+  assert_fatal_error(
+    CALL assert NOT EXISTS some_file
+    MESSAGE "expected path:\n  some_file\nnot to exist")
 endfunction()
 
 function("Directory path assertions")
@@ -64,15 +54,13 @@ function("Directory path assertions")
   assert(IS_DIRECTORY some_directory)
   assert(NOT IS_DIRECTORY some_file)
 
-  mock_message()
-    assert(IS_DIRECTORY some_file)
-  end_mock_message()
-  assert_fatal_error("expected path:\n  some_file\nto be a directory")
+  assert_fatal_error(
+    CALL assert IS_DIRECTORY some_file
+    MESSAGE "expected path:\n  some_file\nto be a directory")
 
-  mock_message()
-    assert(NOT IS_DIRECTORY some_directory)
-  end_mock_message()
-  assert_fatal_error("expected path:\n  some_directory\nnot to be a directory")
+  assert_fatal_error(
+    CALL assert NOT IS_DIRECTORY some_directory
+    MESSAGE "expected path:\n  some_directory\nnot to be a directory")
 endfunction()
 
 function("Regular expression match assertions")
@@ -82,19 +70,13 @@ function("Regular expression match assertions")
     assert("${VALUE}" MATCHES "so.*ing")
     assert(NOT "${VALUE}" MATCHES "so.*other.*ing")
 
-    mock_message()
-      assert(NOT "${VALUE}" MATCHES "so.*ing")
-    end_mock_message()
     assert_fatal_error(
-      "expected string:\n  some string\nnot to match:\n  so.*ing"
-    )
+      CALL assert NOT "${VALUE}" MATCHES "so.*ing"
+      MESSAGE "expected string:\n  some string\nnot to match:\n  so.*ing")
 
-    mock_message()
-      assert("${VALUE}" MATCHES "so.*other.*ing")
-    end_mock_message()
     assert_fatal_error(
-      "expected string:\n  some string\nto match:\n  so.*other.*ing"
-    )
+      CALL assert "${VALUE}" MATCHES "so.*other.*ing"
+      MESSAGE "expected string:\n  some string\nto match:\n  so.*other.*ing")
   endforeach()
 endfunction()
 
@@ -112,21 +94,15 @@ function("String equality assertions")
     endforeach()
 
     foreach(RIGHT_VALUE OTHER_STRING_VAR "${OTHER_STRING_VAR}")
-      mock_message()
-        assert("${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
-      end_mock_message()
       assert_fatal_error(
-        "expected string:\n  some string\nto be equal to:\n  some other string"
-      )
+        CALL assert "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}"
+        MESSAGE "expected string:\n  some string\nto be equal to:\n  some other string")
     endforeach()
 
     foreach(RIGHT_VALUE STRING_VAR "${STRING_VAR}")
-      mock_message()
-        assert(NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
-      end_mock_message()
       assert_fatal_error(
-        "expected string:\n  some string\nnot to be equal to:\n  some string"
-      )
+        CALL assert NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}"
+        MESSAGE "expected string:\n  some string\nnot to be equal to:\n  some string")
     endforeach()
   endforeach()
 endfunction()
@@ -140,53 +116,45 @@ function(call_sample_messages)
 endfunction()
 
 function("Fatal error assertions")
-  function(some_function)
-    message(FATAL_ERROR "some fatal error message")
+  function(throw_fatal_error MESSAGE)
+    message(FATAL_ERROR "${MESSAGE}")
   endfunction()
 
-  mock_message()
-    some_function()
-  end_mock_message()
-  assert_fatal_error("some fatal error message")
+  assert_fatal_error(
+    CALL throw_fatal_error "some fatal error message"
+    MESSAGE "some fatal error message")
 
-  mock_message()
-    some_function()
-    assert_fatal_error("some other fatal error message")
-  end_mock_message()
+  macro(assert_fail)
+    assert_fatal_error(
+      CALL throw_fatal_error "some fatal error message"
+      MESSAGE "some other fatal error message")
+  endmacro()
+
   string(
     JOIN "\n" EXPECTED_MESSAGE
     "expected fatal error message:"
     "  some fatal error message"
     "to be equal to:"
     "  some other fatal error message")
-  assert_fatal_error("${EXPECTED_MESSAGE}")
+  assert_fatal_error(CALL assert_fail MESSAGE "${EXPECTED_MESSAGE}")
 endfunction()
 
 function("Process execution assertions")
   assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true)
   assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false ERROR .*)
 
-  mock_message()
-    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true ERROR .*)
-  end_mock_message()
   assert_fatal_error(
-    "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
+    CALL assert_execute_process COMMAND "${CMAKE_COMMAND}" -E true ERROR .*
+    MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
 
-  mock_message()
-    assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false)
-  end_mock_message()
   assert_fatal_error(
-    "expected command:\n  ${CMAKE_COMMAND} -E false\nnot to fail")
+    CALL assert_execute_process COMMAND "${CMAKE_COMMAND}" -E false
+    MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E false\nnot to fail")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
     OUTPUT "Hello.*!")
 
-  mock_message()
-    assert_execute_process(
-      COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-      OUTPUT "Hi.*!")
-  end_mock_message()
   string(
     JOIN "\n" EXPECTED_MESSAGE
     "expected the output:"
@@ -195,17 +163,16 @@ function("Process execution assertions")
     "  ${CMAKE_COMMAND} -E echo Hello world!"
     "to match:"
     "  Hi.*!")
-  assert_fatal_error("${EXPECTED_MESSAGE}")
+  assert_fatal_error(
+    CALL assert_execute_process
+      COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+      OUTPUT "Hi.*!"
+    MESSAGE "${EXPECTED_MESSAGE}")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E touch /
     ERROR "cmake -E touch: failed to update")
 
-  mock_message()
-    assert_execute_process(
-      COMMAND "${CMAKE_COMMAND}" -E touch /
-      ERROR "cmake -E touch: not failed to update")
-  end_mock_message()
   string(
     JOIN "\n" EXPECTED_MESSAGE
     "expected the error:"
@@ -214,7 +181,11 @@ function("Process execution assertions")
     "  ${CMAKE_COMMAND} -E touch /"
     "to match:"
     "  cmake -E touch: not failed to update")
-  assert_fatal_error("${EXPECTED_MESSAGE}")
+  assert_fatal_error(
+    CALL assert_execute_process
+      COMMAND "${CMAKE_COMMAND}" -E touch /
+      ERROR "cmake -E touch: not failed to update"
+    MESSAGE "${EXPECTED_MESSAGE}")
 endfunction()
 
 function("Mock message")


### PR DESCRIPTION
This pull request resolves #69 by modifying the behavior of the `assert_fatal_error` function to assert the fatal error message of the given function or macro call. This change also updates the tests and documentation accordingly.