### PR TITLE
Fix Mock Message Level

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -122,18 +122,16 @@ endfunction()
 
 # Begins a scope for mocking the 'message' function.
 #
-# This function begins a scope for mocking the 'message' function by modifying
-# its behavior to store the message into a list variable instead of printing it
-# to the log.
+# It begins a scope for mocking the 'message' function by modifying its behavior
+# to store the message into a list variable instead of printing it to the log.
 #
-# Use the 'end_mock_message' function to end the scope for mocking the
-# 'message' function, reverting it to the original behavior.
-function(mock_message)
-  set_property(GLOBAL PROPERTY message_mocked ON)
+# Use the 'end_mock_message' macro to end the scope for mocking the 'message'
+# function, reverting it to the original behavior.
+macro(mock_message)
+  set(MESSAGE_MOCKED ON)
 
   macro(message MODE MESSAGE)
-    get_property(ENABLED GLOBAL PROPERTY message_mocked)
-    if("${ENABLED}")
+    if(MESSAGE_MOCKED)
       list(APPEND ${MODE}_MESSAGES "${MESSAGE}")
       set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
       if("${MODE}" STREQUAL FATAL_ERROR)
@@ -144,18 +142,18 @@ function(mock_message)
     endif()
   endmacro()
 
-  function(mock_message)
-    set_property(GLOBAL PROPERTY message_mocked ON)
-  endfunction()
-endfunction()
+  macro(mock_message)
+    set(MESSAGE_MOCKED ON)
+  endmacro()
+endmacro()
 
 # Ends a scope for mocking the 'message' function.
 #
-# This function ends the scope for mocking the 'message' function, reverting it
-# to the original behavior.
-function(end_mock_message)
-  set_property(GLOBAL PROPERTY message_mocked OFF)
-endfunction()
+# It ends the scope for mocking the 'message' function, reverting it to the
+# original behavior.
+macro(end_mock_message)
+  unset(MESSAGE_MOCKED)
+endmacro()
 
 # Asserts whether a fatal error was received with the expected message.
 #

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -128,10 +128,8 @@ endfunction()
 # Use the 'end_mock_message' macro to end the scope for mocking the 'message'
 # function, reverting it to the original behavior.
 macro(mock_message)
-  set(MESSAGE_MOCKED ON)
-
   macro(message MODE MESSAGE)
-    if(MESSAGE_MOCKED)
+    if(DEFINED MESSAGE_MOCK_LEVEL)
       list(APPEND ${MODE}_MESSAGES "${MESSAGE}")
       set(${MODE}_MESSAGES "${${MODE}_MESSAGES}" PARENT_SCOPE)
       if("${MODE}" STREQUAL FATAL_ERROR)
@@ -143,8 +141,13 @@ macro(mock_message)
   endmacro()
 
   macro(mock_message)
-    set(MESSAGE_MOCKED ON)
+    if(NOT DEFINED MESSAGE_MOCK_LEVEL)
+      set(MESSAGE_MOCK_LEVEL 1)
+    else()
+      math(EXPR MESSAGE_MOCK_LEVEL "${MESSAGE_MOCK_LEVEL} + 1")
+    endif()
   endmacro()
+  mock_message()
 endmacro()
 
 # Ends a scope for mocking the 'message' function.
@@ -152,7 +155,12 @@ endmacro()
 # It ends the scope for mocking the 'message' function, reverting it to the
 # original behavior.
 macro(end_mock_message)
-  unset(MESSAGE_MOCKED)
+  if(DEFINED MESSAGE_MOCK_LEVEL)
+    math(EXPR MESSAGE_MOCK_LEVEL "${MESSAGE_MOCK_LEVEL} - 1")
+    if(MESSAGE_MOCK_LEVEL LESS_EQUAL 0)
+      unset(MESSAGE_MOCK_LEVEL)
+    endif()
+  endif()
 endmacro()
 
 # Asserts whether a fatal error was received with the expected message.

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -219,7 +219,15 @@ endfunction()
 
 function("Mock message")
   mock_message()
-    call_sample_messages()
+    message(WARNING "some warning message")
+    message(WARNING "some other warning message")
+
+    mock_message()
+      message(ERROR "some error message")
+    end_mock_message()
+
+    message(FATAL_ERROR "some fatal error message")
+    message(ERROR "some other error message")
   end_mock_message()
 
   assert(DEFINED WARNING_MESSAGES)


### PR DESCRIPTION
This pull request resolves #73 by addressing the behavior of the `mock_message` and `end_mock_message` functions when called multiple times and at different nest levels. The internal implementation of these functions has been modified to use variables instead of global properties to determine if the message mocking is enabled. This change ensures that the message mocking is correctly handled at each level of nesting.