### PR TITLE
Modify Mock Message Function to Be Internal

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_cmake_test(
   cmake/InternalTest.cmake
   "Variable content retrieval"
   "Assertion message formatting"
+  "Message function mocking"
 )
 
 add_cmake_test(
@@ -27,5 +28,4 @@ add_cmake_test(
   "String equality assertions"
   "Fatal error assertions"
   "Process execution assertions"
-  "Mock message"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -188,27 +188,4 @@ function("Process execution assertions")
     MESSAGE "${EXPECTED_MESSAGE}")
 endfunction()
 
-function("Mock message")
-  mock_message()
-    message(WARNING "some warning message")
-    message(WARNING "some other warning message")
-
-    mock_message()
-      message(ERROR "some error message")
-    end_mock_message()
-
-    message(FATAL_ERROR "some fatal error message")
-    message(ERROR "some other error message")
-  end_mock_message()
-
-  assert(DEFINED WARNING_MESSAGES)
-  assert(WARNING_MESSAGES STREQUAL "some warning message;some other warning message")
-
-  assert(DEFINED ERROR_MESSAGES)
-  assert("${ERROR_MESSAGES}" STREQUAL "some error message")
-
-  assert(DEFINED FATAL_ERROR_MESSAGES)
-  assert("${FATAL_ERROR_MESSAGES}" STREQUAL "some fatal error message")
-endfunction()
-
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/InternalTest.cmake
+++ b/test/cmake/InternalTest.cmake
@@ -26,4 +26,27 @@ function("Assertion message formatting")
   assert(MESSAGE STREQUAL EXPECTED_MESSAGE)
 endfunction()
 
+function("Message function mocking")
+  _assert_internal_mock_message()
+    message(WARNING "some warning message")
+    message(WARNING "some other warning message")
+
+    _assert_internal_mock_message()
+      message(ERROR "some error message")
+    _assert_internal_end_mock_message()
+
+    message(FATAL_ERROR "some fatal error message")
+    message(ERROR "some other error message")
+  _assert_internal_end_mock_message()
+
+  assert(DEFINED WARNING_MESSAGES)
+  assert(WARNING_MESSAGES STREQUAL "some warning message;some other warning message")
+
+  assert(DEFINED ERROR_MESSAGES)
+  assert("${ERROR_MESSAGES}" STREQUAL "some error message")
+
+  assert(DEFINED FATAL_ERROR_MESSAGES)
+  assert("${FATAL_ERROR_MESSAGES}" STREQUAL "some fatal error message")
+endfunction()
+
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #75 by modifying the mock message functions to be internal functions.