### PR TITLE
Adjust Assertion Message When Inputs Are Variables

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -3,23 +3,6 @@
 
 include_guard(GLOBAL)
 
-# Retrieves the content of the given variable.
-#
-# If the given variable is defined, it sets the output variable to the content
-# of the variable. Otherwise, it sets the output variable to the name of the
-# variable.
-#
-# Arguments:
-#   - VARIABLE: The variable to get the content from.
-#   - OUTPUT_VARIABLE: The output variable that holds the content of the variable.
-function(_assert_internal_get_content VARIABLE OUTPUT_VARIABLE)
-  if(DEFINED "${VARIABLE}")
-    set("${OUTPUT_VARIABLE}" "${${VARIABLE}}" PARENT_SCOPE)
-  else()
-    set("${OUTPUT_VARIABLE}" "${VARIABLE}" PARENT_SCOPE)
-  endif()
-endfunction()
-
 # Formats an assertion message with indentation on even lines.
 #
 # Arguments:

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -98,11 +98,35 @@ function(assert)
               MESSAGE "expected string:" "${ARGV0}" "to match:" "${ARGV2}")
           endif()
         elseif(ARGV1 STREQUAL STREQUAL)
-          _assert_internal_get_content("${ARGV0}" STRING1_CONTENT)
-          _assert_internal_get_content("${ARGV2}" STRING2_CONTENT)
-          _assert_internal_format_message(
-            MESSAGE "expected string:" "${STRING1_CONTENT}"
-            "to be equal to:" "${STRING2_CONTENT}")
+          if(DEFINED "${ARGV0}")
+            if(DEFINED "${ARGV2}")
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${${ARGV0}}"
+                "of variable:" "${ARGV0}"
+                "to be equal to string:" "${${ARGV2}}"
+                "of variable:" "${ARGV2}")
+            else()
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${${ARGV0}}"
+                "of variable:" "${ARGV0}"
+                "to be equal to:" "${ARGV2}")
+            endif()
+          else()
+            if(DEFINED "${ARGV2}")
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${ARGV0}"
+                "to be equal to string:" "${${ARGV2}}"
+                "of variable:" "${ARGV2}")
+            else()
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${ARGV0}"
+                "to be equal to:" "${ARGV2}")
+            endif()
+          endif()
         endif()
       endif()
     elseif(ARGC EQUAL 4)
@@ -119,11 +143,35 @@ function(assert)
               MESSAGE "expected string:" "${ARGV1}" "not to match:" "${ARGV3}")
           endif()
         elseif(ARGV2 STREQUAL STREQUAL)
-          _assert_internal_get_content("${ARGV1}" STRING1_CONTENT)
-          _assert_internal_get_content("${ARGV3}" STRING2_CONTENT)
-          _assert_internal_format_message(
-            MESSAGE "expected string:" "${STRING1_CONTENT}"
-            "not to be equal to:" "${STRING2_CONTENT}")
+          if(DEFINED "${ARGV1}")
+            if(DEFINED "${ARGV3}")
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${${ARGV1}}"
+                "of variable:" "${ARGV1}"
+                "not to be equal to string:" "${${ARGV3}}"
+                "of variable:" "${ARGV3}")
+            else()
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${${ARGV1}}"
+                "of variable:" "${ARGV1}"
+                "not to be equal to:" "${ARGV3}")
+            endif()
+          else()
+            if(DEFINED "${ARGV3}")
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${ARGV1}"
+                "not to be equal to string:" "${${ARGV3}}"
+                "of variable:" "${ARGV3}")
+            else()
+              _assert_internal_format_message(
+                MESSAGE
+                "expected string:" "${ARGV1}"
+                "not to be equal to:" "${ARGV3}")
+            endif()
+          endif()
         endif()
       endif()
     endif()

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -87,10 +87,16 @@ function(assert)
         endif()
       else()
         if(ARGV1 STREQUAL MATCHES)
-          _assert_internal_get_content("${ARGV0}" STRING_CONTENT)
-          _assert_internal_format_message(
-            MESSAGE "expected string:" "${STRING_CONTENT}"
-            "to match:" "${ARGV2}")
+          if(DEFINED "${ARGV0}")
+            _assert_internal_format_message(
+              MESSAGE
+              "expected string:" "${${ARGV0}}"
+              "of variable:" "${ARGV0}"
+              "to match:" "${ARGV2}")
+          else()
+            _assert_internal_format_message(
+              MESSAGE "expected string:" "${ARGV0}" "to match:" "${ARGV2}")
+          endif()
         elseif(ARGV1 STREQUAL STREQUAL)
           _assert_internal_get_content("${ARGV0}" STRING1_CONTENT)
           _assert_internal_get_content("${ARGV2}" STRING2_CONTENT)
@@ -102,10 +108,16 @@ function(assert)
     elseif(ARGC EQUAL 4)
       if(ARGV0 STREQUAL NOT)
         if(ARGV2 STREQUAL MATCHES)
-          _assert_internal_get_content("${ARGV1}" STRING_CONTENT)
-          _assert_internal_format_message(
-            MESSAGE "expected string:" "${STRING_CONTENT}"
-            "not to match:" "${ARGV3}")
+          if(DEFINED "${ARGV1}")
+            _assert_internal_format_message(
+              MESSAGE
+              "expected string:" "${${ARGV1}}"
+              "of variable:" "${ARGV1}"
+              "not to match:" "${ARGV3}")
+          else()
+            _assert_internal_format_message(
+              MESSAGE "expected string:" "${ARGV1}" "not to match:" "${ARGV3}")
+          endif()
         elseif(ARGV2 STREQUAL STREQUAL)
           _assert_internal_get_content("${ARGV1}" STRING1_CONTENT)
           _assert_internal_get_content("${ARGV3}" STRING2_CONTENT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,6 @@ endfunction()
 
 add_cmake_test(
   cmake/InternalTest.cmake
-  "Variable content retrieval"
   "Assertion message formatting"
   "Message function mocking"
 )

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -103,27 +103,89 @@ function("String equality assertions")
   set(STRING_VAR "some string")
   set(OTHER_STRING_VAR "some other string")
 
-  foreach(LEFT_VALUE STRING_VAR "${STRING_VAR}")
-    foreach(RIGHT_VALUE STRING_VAR "${STRING_VAR}")
-      assert("${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
-    endforeach()
+  assert("some string" STREQUAL "some string")
+  assert(NOT "some string" STREQUAL "some other string")
 
-    foreach(RIGHT_VALUE OTHER_STRING_VAR "${OTHER_STRING_VAR}")
-      assert(NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}")
-    endforeach()
+  assert(STRING_VAR STREQUAL "some string")
+  assert(NOT STRING_VAR STREQUAL "some other string")
 
-    foreach(RIGHT_VALUE OTHER_STRING_VAR "${OTHER_STRING_VAR}")
-      assert_fatal_error(
-        CALL assert "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}"
-        MESSAGE "expected string:\n  some string\nto be equal to:\n  some other string")
-    endforeach()
+  assert("some string" STREQUAL STRING_VAR)
+  assert(NOT "some string" STREQUAL OTHER_STRING_VAR)
 
-    foreach(RIGHT_VALUE STRING_VAR "${STRING_VAR}")
-      assert_fatal_error(
-        CALL assert NOT "${LEFT_VALUE}" STREQUAL "${RIGHT_VALUE}"
-        MESSAGE "expected string:\n  some string\nnot to be equal to:\n  some string")
-    endforeach()
-  endforeach()
+  assert(STRING_VAR STREQUAL STRING_VAR)
+  assert(NOT STRING_VAR STREQUAL OTHER_STRING_VAR)
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "not to be equal to:\n  some string")
+  assert_fatal_error(
+    CALL assert NOT "some string" STREQUAL "some string"
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "to be equal to:\n  some other string")
+  assert_fatal_error(
+    CALL assert "some string" STREQUAL "some other string"
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "not to be equal to:\n  some string")
+  assert_fatal_error(
+    CALL assert NOT STRING_VAR STREQUAL "some string"
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "to be equal to:\n  some other string")
+  assert_fatal_error(
+    CALL assert STRING_VAR STREQUAL "some other string"
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "not to be equal to string:\n  some string"
+    "of variable:\n  STRING_VAR")
+  assert_fatal_error(
+    CALL assert NOT "some string" STREQUAL STRING_VAR
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "to be equal to string:\n  some other string"
+    "of variable:\n  OTHER_STRING_VAR")
+  assert_fatal_error(
+    CALL assert "some string" STREQUAL OTHER_STRING_VAR
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "not to be equal to string:\n  some string"
+    "of variable:\n  STRING_VAR")
+  assert_fatal_error(
+    CALL assert NOT STRING_VAR STREQUAL STRING_VAR
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "to be equal to string:\n  some other string"
+    "of variable:\n  OTHER_STRING_VAR")
+  assert_fatal_error(
+    CALL assert STRING_VAR STREQUAL OTHER_STRING_VAR
+    MESSAGE "${EXPECTED_MESSAGE}")
 endfunction()
 
 function(call_sample_messages)

--- a/test/cmake/AssertionTest.cmake
+++ b/test/cmake/AssertionTest.cmake
@@ -66,18 +66,37 @@ endfunction()
 function("Regular expression match assertions")
   set(STRING_VAR "some string")
 
-  foreach(VALUE STRING_VAR "${STRING_VAR}")
-    assert("${VALUE}" MATCHES "so.*ing")
-    assert(NOT "${VALUE}" MATCHES "so.*other.*ing")
+  assert("some string" MATCHES "so.*ing")
+  assert(NOT "some string" MATCHES "so.*other.*ing")
 
-    assert_fatal_error(
-      CALL assert NOT "${VALUE}" MATCHES "so.*ing"
-      MESSAGE "expected string:\n  some string\nnot to match:\n  so.*ing")
+  assert(STRING_VAR MATCHES "so.*ing")
+  assert(NOT STRING_VAR MATCHES "so.*other.*ing")
 
-    assert_fatal_error(
-      CALL assert "${VALUE}" MATCHES "so.*other.*ing"
-      MESSAGE "expected string:\n  some string\nto match:\n  so.*other.*ing")
-  endforeach()
+  assert_fatal_error(
+    CALL assert NOT "some string" MATCHES "so.*ing"
+    MESSAGE "expected string:\n  some string\nnot to match:\n  so.*ing")
+
+  assert_fatal_error(
+    CALL assert "some string" MATCHES "so.*other.*ing"
+    MESSAGE "expected string:\n  some string\nto match:\n  so.*other.*ing")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "not to match:\n  so.*ing")
+  assert_fatal_error(
+    CALL assert NOT STRING_VAR MATCHES "so.*ing"
+    MESSAGE "${EXPECTED_MESSAGE}")
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected string:\n  some string"
+    "of variable:\n  STRING_VAR"
+    "to match:\n  so.*other.*ing")
+  assert_fatal_error(
+    CALL assert STRING_VAR MATCHES "so.*other.*ing"
+    MESSAGE "${EXPECTED_MESSAGE}")
 endfunction()
 
 function("String equality assertions")

--- a/test/cmake/InternalTest.cmake
+++ b/test/cmake/InternalTest.cmake
@@ -2,15 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 include(Assertion)
 
-function("Variable content retrieval")
-  _assert_internal_get_content("some value" CONTENT)
-  assert(CONTENT STREQUAL "some value")
-
-  set(SOME_VARIABLE "some other value")
-  _assert_internal_get_content(SOME_VARIABLE CONTENT)
-  assert(CONTENT STREQUAL "some other value")
-endfunction()
-
 function("Assertion message formatting")
   _assert_internal_format_message(
     MESSAGE "first line" "second line" "third line\nthird line" "fourth line\nfourth line")


### PR DESCRIPTION
This pull request resolves #79 by adjusting the assertion messages for string matching and equality assertions when the inputs are variables instead of strings. This change also removes the unused `_assert_internal_get_content` internal function, which was previously used for specifying the assertion messages for string matching and equality assertions.