### PR TITLE
Show Error in Execute Process Assertion

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -244,7 +244,8 @@ function(assert_execute_process)
   elseif(NOT DEFINED ARG_ERROR AND NOT RES EQUAL 0)
     string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
     _assert_internal_format_message(
-      MESSAGE "expected command:" "${COMMAND}" "not to fail")
+      MESSAGE "expected command:" "${COMMAND}"
+      "not to fail with error:" "${ERR}")
     message(FATAL_ERROR "${MESSAGE}")
   elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
     string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")

--- a/test/AssertExecuteProcess.cmake
+++ b/test/AssertExecuteProcess.cmake
@@ -18,7 +18,8 @@ section("execute process assertions")
     JOIN "\n" EXPECTED_MESSAGE
     "expected command:"
     "  ${CMAKE_COMMAND} -E make_directory some-file"
-    "not to fail")
+    "not to fail with error:"
+    "  Error creating directory \"some-file\".")
   assert_fatal_error(
     CALL assert_execute_process
       COMMAND "${CMAKE_COMMAND}" -E make_directory some-file

--- a/test/AssertExecuteProcess.cmake
+++ b/test/AssertExecuteProcess.cmake
@@ -3,16 +3,26 @@ cmake_minimum_required(VERSION 3.17)
 include(Assertion)
 
 section("execute process assertions")
+  file(TOUCH some-file)
+
   assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E true)
-  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -E false ERROR .*)
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E make_directory some-file ERROR .*)
 
   assert_fatal_error(
     CALL assert_execute_process COMMAND "${CMAKE_COMMAND}" -E true ERROR .*
     MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
 
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected command:"
+    "  ${CMAKE_COMMAND} -E make_directory some-file"
+    "not to fail")
   assert_fatal_error(
-    CALL assert_execute_process COMMAND "${CMAKE_COMMAND}" -E false
-    MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E false\nnot to fail")
+    CALL assert_execute_process
+      COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+    MESSAGE "${EXPECTED_MESSAGE}")
 endsection()
 
 section("execute process output assertions")
@@ -36,21 +46,23 @@ section("execute process output assertions")
 endsection()
 
 section("execute process error assertions")
+  file(TOUCH some-file)
+
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" -E touch /
-    ERROR "cmake -E touch: failed to update")
+    COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+    ERROR "Error creating directory \"some-file\".")
 
   string(
     JOIN "\n" EXPECTED_MESSAGE
     "expected the error:"
-    "  cmake -E touch: failed to update \"/\"."
+    "  Error creating directory \"some-file\"."
     "of command:"
-    "  ${CMAKE_COMMAND} -E touch /"
+    "  ${CMAKE_COMMAND} -E make_directory some-file"
     "to match:"
-    "  cmake -E touch: not failed to update")
+    "  Error creating directory \"some-other-file\".")
   assert_fatal_error(
     CALL assert_execute_process
-      COMMAND "${CMAKE_COMMAND}" -E touch /
-      ERROR "cmake -E touch: not failed to update"
+      COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+      ERROR "Error creating directory \"some-other-file\"."
     MESSAGE "${EXPECTED_MESSAGE}")
 endsection()


### PR DESCRIPTION
This pull request resolves #89 by updating the `assert_execute_process` function to display an error if the executed process fails to run. This change also updates the tests to call commands that output an error upon failure.