### PR TITLE
Fix Argument Requirements for Mocked Message Function

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -181,18 +181,20 @@ function(assert_fatal_error)
   if(NOT MESSAGE_MOCKED)
     # Override the `message` function to allow the behavior to be mocked by
     # asserting a fatal error message.
-    function(message MODE MESSAGE)
+    function(message ARG0)
+      cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "")
       list(LENGTH _ASSERT_INTERNAL_EXPECTED_MESSAGES EXPECTED_MESSAGE_LENGTH)
-      if(EXPECTED_MESSAGE_LENGTH GREATER 0 AND MODE STREQUAL FATAL_ERROR)
+      if(EXPECTED_MESSAGE_LENGTH GREATER 0 AND ARG0 STREQUAL FATAL_ERROR)
         list(POP_BACK _ASSERT_INTERNAL_EXPECTED_MESSAGES EXPECTED_MESSAGE)
-        if(NOT MESSAGE STREQUAL EXPECTED_MESSAGE)
+        if(NOT "${ARG_UNPARSED_ARGUMENTS}" STREQUAL EXPECTED_MESSAGE)
           _assert_internal_format_message(
-            ASSERT_MESSAGE "expected fatal error message:" "${MESSAGE}"
+            ASSERT_MESSAGE
+            "expected fatal error message:" "${ARG_UNPARSED_ARGUMENTS}"
             "to be equal to:" "${EXPECTED_MESSAGE}")
           message(FATAL_ERROR "${ASSERT_MESSAGE}")
         endif()
       else()
-        _message("${MODE}" "${MESSAGE}")
+        _message("${ARG0}" ${ARG_UNPARSED_ARGUMENTS})
       endif()
     endfunction()
     set_property(GLOBAL PROPERTY _assert_internal_message_mocked ON)

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -2,22 +2,30 @@ cmake_minimum_required(VERSION 3.5)
 
 find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
-function(throw_fatal_error MESSAGE)
-  message(FATAL_ERROR "${MESSAGE}")
-endfunction()
+section("fatal error assertions")
+  function(throw_fatal_error MESSAGE)
+    message(FATAL_ERROR "${MESSAGE}")
+  endfunction()
 
-assert_fatal_error(
-  CALL throw_fatal_error "some fatal error message"
-  MESSAGE "some fatal error message")
-
-macro(assert_fail)
   assert_fatal_error(
     CALL throw_fatal_error "some fatal error message"
-    MESSAGE "some other fatal error message")
-endmacro()
+    MESSAGE "some fatal error message")
 
-string(
-  JOIN "\n" EXPECTED_MESSAGE
-  "expected fatal error message:\n  some fatal error message"
-  "to be equal to:\n  some other fatal error message")
-assert_fatal_error(CALL assert_fail MESSAGE "${EXPECTED_MESSAGE}")
+  macro(assert_fail)
+    assert_fatal_error(
+      CALL throw_fatal_error "some fatal error message"
+      MESSAGE "some other fatal error message")
+  endmacro()
+
+  string(
+    JOIN "\n" EXPECTED_MESSAGE
+    "expected fatal error message:\n  some fatal error message"
+    "to be equal to:\n  some other fatal error message")
+  assert_fatal_error(CALL assert_fail MESSAGE "${EXPECTED_MESSAGE}")
+endsection()
+
+section("mocked message check")
+  message("some unspecified message")
+  message(STATUS "some status message")
+  message(STATUS "some status message" " with additional information")
+endsection()


### PR DESCRIPTION
This pull request resolves #91 by fixing the argument requirements for the mocked `message` command. This change also adds a test to check whether the `message` command can be called properly after being mocked.