### PR TITLE
Allow Fatal Error Assertions to Accept Expected Message as Multiple Values

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -168,13 +168,13 @@ endfunction()
 
 # Asserts whether a command call throws a fatal error message.
 #
-# assert_fatal_error(CALL <command> [<arg>...] MESSAGE <message>)
+# assert_fatal_error(CALL <command> [<arg>...] MESSAGE <message>...)
 #
 # This function asserts whether a function or macro named `<command>` called
 # with the specified arguments throws the expected `<message>` fatal error
 # message.
 function(assert_fatal_error)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" MESSAGE CALL)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;MESSAGE")
 
   # Override the `message` function if it has not been overridden.
   get_property(MESSAGE_MOCKED GLOBAL PROPERTY _assert_internal_message_mocked)
@@ -200,7 +200,8 @@ function(assert_fatal_error)
     set_property(GLOBAL PROPERTY _assert_internal_message_mocked ON)
   endif()
 
-  list(APPEND _ASSERT_INTERNAL_EXPECTED_MESSAGES "${ARG_MESSAGE}")
+  string(JOIN "" EXPECTED_MESSAGE ${ARG_MESSAGE})
+  list(APPEND _ASSERT_INTERNAL_EXPECTED_MESSAGES "${EXPECTED_MESSAGE}")
   list(POP_FRONT ARG_CALL COMMAND)
   cmake_language(CALL "${COMMAND}" ${ARG_CALL})
 endfunction()

--- a/test/Assert.cmake
+++ b/test/Assert.cmake
@@ -80,23 +80,17 @@ section("regular expression match assertions")
     CALL assert "some string" MATCHES "so.*other.*ing"
     MESSAGE "expected string:\n  some string\nto match:\n  so.*other.*ing")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "not to match:\n  so.*ing")
   assert_fatal_error(
     CALL assert NOT STRING_VAR MATCHES "so.*ing"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "not to match:\n  so.*ing")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "to match:\n  so.*other.*ing")
   assert_fatal_error(
     CALL assert STRING_VAR MATCHES "so.*other.*ing"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "to match:\n  so.*other.*ing")
 endsection()
 
 section("string equality assertions")
@@ -115,75 +109,51 @@ section("string equality assertions")
   assert(STRING_VAR STREQUAL STRING_VAR)
   assert(NOT STRING_VAR STREQUAL OTHER_STRING_VAR)
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "not to be equal to:\n  some string")
   assert_fatal_error(
     CALL assert NOT "some string" STREQUAL "some string"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "not to be equal to:\n  some string")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "to be equal to:\n  some other string")
   assert_fatal_error(
     CALL assert "some string" STREQUAL "some other string"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "to be equal to:\n  some other string")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "not to be equal to:\n  some string")
   assert_fatal_error(
     CALL assert NOT STRING_VAR STREQUAL "some string"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "not to be equal to:\n  some string")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "to be equal to:\n  some other string")
   assert_fatal_error(
     CALL assert STRING_VAR STREQUAL "some other string"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "to be equal to:\n  some other string")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "not to be equal to string:\n  some string"
-    "of variable:\n  STRING_VAR")
   assert_fatal_error(
     CALL assert NOT "some string" STREQUAL STRING_VAR
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "not to be equal to string:\n  some string\n"
+      "of variable:\n  STRING_VAR")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "to be equal to string:\n  some other string"
-    "of variable:\n  OTHER_STRING_VAR")
   assert_fatal_error(
     CALL assert "some string" STREQUAL OTHER_STRING_VAR
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "to be equal to string:\n  some other string\n"
+      "of variable:\n  OTHER_STRING_VAR")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "not to be equal to string:\n  some string"
-    "of variable:\n  STRING_VAR")
   assert_fatal_error(
     CALL assert NOT STRING_VAR STREQUAL STRING_VAR
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "not to be equal to string:\n  some string\n"
+      "of variable:\n  STRING_VAR")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected string:\n  some string"
-    "of variable:\n  STRING_VAR"
-    "to be equal to string:\n  some other string"
-    "of variable:\n  OTHER_STRING_VAR")
   assert_fatal_error(
     CALL assert STRING_VAR STREQUAL OTHER_STRING_VAR
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected string:\n  some string\n"
+      "of variable:\n  STRING_VAR\n"
+      "to be equal to string:\n  some other string\n"
+      "of variable:\n  OTHER_STRING_VAR")
 endsection()

--- a/test/AssertExecuteProcess.cmake
+++ b/test/AssertExecuteProcess.cmake
@@ -14,15 +14,12 @@ section("execute process assertions")
     CALL assert_execute_process "${CMAKE_COMMAND}" -E true ERROR .*
     MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected command:"
-    "  ${CMAKE_COMMAND} -E make_directory some-file"
-    "not to fail with error:"
-    "  Error creating directory \"some-file\".")
   assert_fatal_error(
     CALL assert_execute_process "${CMAKE_COMMAND}" -E make_directory some-file
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected command:\n"
+      "  ${CMAKE_COMMAND} -E make_directory some-file\n"
+      "not to fail with error:\n"
+      "  Error creating directory \"some-file\".")
 endsection()
 
 section("execute process output assertions")
@@ -30,19 +27,16 @@ section("execute process output assertions")
     COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
     OUTPUT "Hello.*!")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected the output:"
-    "  Hello world!"
-    "of command:"
-    "  ${CMAKE_COMMAND} -E echo Hello world!"
-    "to match:"
-    "  Hi.*!")
   assert_fatal_error(
     CALL assert_execute_process
       COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
       OUTPUT "Hi.*!"
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected the output:\n"
+      "  Hello world!\n"
+      "of command:\n"
+      "  ${CMAKE_COMMAND} -E echo Hello world!\n"
+      "to match:\n"
+      "  Hi.*!")
 endsection()
 
 section("execute process error assertions")
@@ -52,17 +46,14 @@ section("execute process error assertions")
     COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
     ERROR "Error creating directory \"some-file\".")
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected the error:"
-    "  Error creating directory \"some-file\"."
-    "of command:"
-    "  ${CMAKE_COMMAND} -E make_directory some-file"
-    "to match:"
-    "  Error creating directory \"some-other-file\".")
   assert_fatal_error(
     CALL assert_execute_process
       COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
       ERROR "Error creating directory \"some-other-file\"."
-    MESSAGE "${EXPECTED_MESSAGE}")
+    MESSAGE "expected the error:\n"
+      "  Error creating directory \"some-file\".\n"
+      "of command:\n"
+      "  ${CMAKE_COMMAND} -E make_directory some-file\n"
+      "to match:\n"
+      "  Error creating directory \"some-other-file\".")
 endsection()

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -17,11 +17,12 @@ section("fatal error assertions")
       MESSAGE "some other fatal error message")
   endmacro()
 
-  string(
-    JOIN "\n" EXPECTED_MESSAGE
-    "expected fatal error message:\n  some fatal error message"
-    "to be equal to:\n  some other fatal error message")
-  assert_fatal_error(CALL assert_fail MESSAGE "${EXPECTED_MESSAGE}")
+  assert_fatal_error(
+    CALL assert_fail
+    MESSAGE "expected fatal error message:\n"
+      "  some fatal error message\n"
+      "to be equal to:\n"
+      "  some other fatal error message")
 endsection()
 
 section("mocked message check")


### PR DESCRIPTION
This pull request resolves #100 by modifying the `MESSAGE` option in the `assert_fatal_error` function to allow multiple values, simplifying the fatal error message if the expected message contains new lines.