### PR TITLE
Fix Integration Guide in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This module can be integrated into a CMake project in the following ways:
 - Use [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to add this package to the CMake project:
   ```cmake
   cpmaddpackage(gh:threeal/assertion-cmake@0.3.0)
-  include(${Assertion_SOURCE_DIR}/cmake/Assertion.cmake)
   ```
 
 ## Example Usages


### PR DESCRIPTION
This pull request fixes the integration guide in the `README.md` file. Since #97, it is no longer necessary to include the `Assertion.cmake` module if the project is being included as a subdirectory (as in CPM.cmake).