### PR TITLE
Modify Fatal Error Assertion to Match the Expected Error

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -161,8 +161,8 @@ endfunction()
 # assert_fatal_error(CALL <command> [<arg>...] MESSAGE <message>...)
 #
 # This function asserts whether a function or macro named `<command>` called
-# with the specified arguments throws the expected `<message>` fatal error
-# message.
+# with the specified arguments throws a fatal error message that matches the
+# expected `<message>`.
 function(assert_fatal_error)
   cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;MESSAGE")
 
@@ -176,11 +176,11 @@ function(assert_fatal_error)
       list(LENGTH _ASSERT_INTERNAL_EXPECTED_MESSAGES EXPECTED_MESSAGE_LENGTH)
       if(EXPECTED_MESSAGE_LENGTH GREATER 0 AND ARG0 STREQUAL FATAL_ERROR)
         list(POP_BACK _ASSERT_INTERNAL_EXPECTED_MESSAGES EXPECTED_MESSAGE)
-        if(NOT "${ARG_UNPARSED_ARGUMENTS}" STREQUAL EXPECTED_MESSAGE)
+        if(NOT "${ARG_UNPARSED_ARGUMENTS}" MATCHES "${EXPECTED_MESSAGE}")
           _assert_internal_format_message(
             ASSERT_MESSAGE
             "expected fatal error message:" "${ARG_UNPARSED_ARGUMENTS}"
-            "to be equal to:" "${EXPECTED_MESSAGE}")
+            "to match:" "${EXPECTED_MESSAGE}")
           message(FATAL_ERROR "${ASSERT_MESSAGE}")
         endif()
       else()

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -9,20 +9,20 @@ section("fatal error assertions")
 
   assert_fatal_error(
     CALL throw_fatal_error "some fatal error message"
-    MESSAGE "some fatal error message")
+    MESSAGE "some.*error message")
 
   macro(assert_fail)
     assert_fatal_error(
       CALL throw_fatal_error "some fatal error message"
-      MESSAGE "some other fatal error message")
+      MESSAGE "some other.*error message")
   endmacro()
 
   assert_fatal_error(
     CALL assert_fail
     MESSAGE "expected fatal error message:\n"
       "  some fatal error message\n"
-      "to be equal to:\n"
-      "  some other fatal error message")
+      "to match:\n"
+      "  some other.*error message")
 endsection()
 
 section("mocked message check")


### PR DESCRIPTION
This pull request resolves #112 by modifying the `assert_fatal_error` function to compare the fatal error message with the expected error using a regular expression match instead of string equality.