### PR TITLE
Allow Execute Process Assertion to Accept Output and Error as Multiple Values

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -199,7 +199,7 @@ endfunction()
 # Asserts whether the given command correctly executes a process.
 #
 # assert_execute_process(
-#   [COMMAND] <command> [<arg>...] [OUTPUT <output>] [ERROR <error>])
+#   [COMMAND] <command> [<arg>...] [OUTPUT <output>...] [ERROR <error>...])
 #
 # This function asserts whether the given command and arguments successfully
 # execute a process.
@@ -211,10 +211,18 @@ endfunction()
 # arguments fail to execute a process. It also asserts whether the error of the
 # executed process matches the expected `<error>`.
 function(assert_execute_process)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "OUTPUT;ERROR" "COMMAND")
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "COMMAND;OUTPUT;ERROR")
 
   if(NOT DEFINED ARG_COMMAND)
     set(ARG_COMMAND ${ARG_UNPARSED_ARGUMENTS})
+  endif()
+
+  if(DEFINED ARG_OUTPUT)
+    string(JOIN "" EXPECTED_OUTPUT ${ARG_OUTPUT})
+  endif()
+
+  if(DEFINED ARG_ERROR)
+    string(JOIN "" EXPECTED_ERROR ${ARG_ERROR})
   endif()
 
   execute_process(
@@ -234,19 +242,19 @@ function(assert_execute_process)
       MESSAGE "expected command:" "${COMMAND}"
         "not to fail with error:" "${ERR}")
     message(FATAL_ERROR "${MESSAGE}")
-  elseif(DEFINED ARG_OUTPUT AND NOT "${OUT}" MATCHES "${ARG_OUTPUT}")
+  elseif(DEFINED EXPECTED_OUTPUT AND NOT "${OUT}" MATCHES "${EXPECTED_OUTPUT}")
     string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
     _assert_internal_format_message(
       MESSAGE "expected the output:" "${OUT}"
         "of command:" "${COMMAND}"
-        "to match:" "${ARG_OUTPUT}")
+        "to match:" "${EXPECTED_OUTPUT}")
     message(FATAL_ERROR "${MESSAGE}")
-  elseif(DEFINED ARG_ERROR AND NOT "${ERR}" MATCHES "${ARG_ERROR}")
+  elseif(DEFINED EXPECTED_ERROR AND NOT "${ERR}" MATCHES "${EXPECTED_ERROR}")
     string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
     _assert_internal_format_message(
       MESSAGE "expected the error:" "${ERR}"
         "of command:" "${COMMAND}"
-        "to match:" "${ARG_ERROR}")
+        "to match:" "${EXPECTED_ERROR}")
     message(FATAL_ERROR "${MESSAGE}")
   endif()
 endfunction()

--- a/test/AssertExecuteProcess.cmake
+++ b/test/AssertExecuteProcess.cmake
@@ -25,18 +25,18 @@ endsection()
 section("execute process output assertions")
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-    OUTPUT "Hello.*!")
+    OUTPUT "Hello" ".*!")
 
   assert_fatal_error(
     CALL assert_execute_process
       COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-      OUTPUT "Hi.*!"
+      OUTPUT "Hello" ".*earth!"
     MESSAGE "expected the output:\n"
-      "  Hello world!\n"
+      ".*\n"
       "of command:\n"
       "  ${CMAKE_COMMAND} -E echo Hello world!\n"
       "to match:\n"
-      "  Hi.*!")
+      "  Hello.*earth!")
 endsection()
 
 section("execute process error assertions")
@@ -44,16 +44,16 @@ section("execute process error assertions")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-    ERROR "Error creating directory \"some-file\".")
+    ERROR "Error creating directory" ".*some-file")
 
   assert_fatal_error(
     CALL assert_execute_process
       COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-      ERROR "Error creating directory \"some-other-file\"."
+      ERROR "Error creating directory" ".*some-other-file"
     MESSAGE "expected the error:\n"
-      "  Error creating directory \"some-file\".\n"
+      ".*\n"
       "of command:\n"
       "  ${CMAKE_COMMAND} -E make_directory some-file\n"
       "to match:\n"
-      "  Error creating directory \"some-other-file\".")
+      "  Error creating directory.*some-other-file")
 endsection()


### PR DESCRIPTION
This pull request resolves #118 by modifying the `OUTPUT` and `ERROR` options in the `assert_execute_process` function to allow multiple values, simplifying the execute process assertion if the expected message contains new lines.