### PR TITLE
Allow Module to Optionally Include Other Modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if(ASSERT_ENABLE_TESTS)
   enable_testing()
 
   add_test(
+    NAME "inclusion of other modules"
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/IncludeOtherModules.cmake)
+
+  add_test(
     NAME "condition assertions"
     COMMAND "${CMAKE_COMMAND}"
       -P ${CMAKE_CURRENT_SOURCE_DIR}/test/Assert.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,32 +18,38 @@ if(ASSERT_ENABLE_TESTS)
   add_test(
     NAME "inclusion of other modules"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/IncludeOtherModules.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/IncludeOtherModules.cmake)
 
   add_test(
     NAME "condition assertions"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/Assert.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/Assert.cmake)
 
   add_test(
     NAME "fatal error assertions"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertFatalError.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertFatalError.cmake)
 
   add_test(
     NAME "execute process assertions"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertExecuteProcess.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertExecuteProcess.cmake)
 
   add_test(
     NAME "internal assertion message formatting"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/InternalFormatMessage.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/InternalFormatMessage.cmake)
 
   add_test(
     NAME "section creation"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/SectionCreation.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/test/SectionCreation.cmake)
 endif()
 
 if(ASSERT_ENABLE_INSTALL)

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -1,8 +1,6 @@
 # This code is licensed under the terms of the MIT License.
 # Copyright (c) 2024 Alfi Maulana
 
-include_guard(GLOBAL)
-
 # Formats an assertion message with indentation on each even line.
 #
 # _assert_internal_format_message(<out_var> [<lines>...])
@@ -284,3 +282,18 @@ function(endsection)
   set(CMAKE_MESSAGE_INDENT "${CMAKE_MESSAGE_INDENT}" PARENT_SCOPE)
   message(CHECK_PASS passed)
 endfunction()
+
+# These lines allow this module to include other modules when run in script mode
+# by passing the paths of the other modules as arguments after `--`.
+if(NOT DEFINED CMAKE_PARENT_LIST_FILE)
+  math(EXPR END "${CMAKE_ARGC} - 1")
+  foreach(I RANGE 0 "${END}")
+    if("${CMAKE_ARGV${I}}" STREQUAL --)
+      math(EXPR I "${I} + 1")
+      foreach(I RANGE "${I}" "${END}")
+        include("${CMAKE_ARGV${I}}")
+      endforeach()
+      break()
+    endif()
+  endforeach()
+endif()

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -1,6 +1,8 @@
 # This code is licensed under the terms of the MIT License.
 # Copyright (c) 2024 Alfi Maulana
 
+cmake_minimum_required(VERSION 3.17)
+
 # Formats an assertion message with indentation on each even line.
 #
 # _assert_internal_format_message(<out_var> [<lines>...])

--- a/test/Assert.cmake
+++ b/test/Assert.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 section("boolean assertions")
   assert(TRUE)
   assert(NOT FALSE)

--- a/test/AssertExecuteProcess.cmake
+++ b/test/AssertExecuteProcess.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 section("execute process assertions")
   file(TOUCH some-file)
 

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 section("fatal error assertions")
   function(throw_fatal_error MESSAGE)
     message(FATAL_ERROR "${MESSAGE}")

--- a/test/IncludeOtherModules.cmake
+++ b/test/IncludeOtherModules.cmake
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.17)
+
+find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+
+section("it should include modules")
+  file(WRITE foo.cmake "message(STATUS \"foo\")\n")
+  file(WRITE goo.cmake "message(STATUS \"goo\")\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+      -- foo.cmake goo.cmake
+    OUTPUT ".*foo\n.*goo")
+endsection()
+
+section("it should not include any modules if arguments are not specified")
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+    OUTPUT "^$")
+endsection()
+
+section("it should not include any modules if included by another module")
+  file(WRITE root.cmake
+    "include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -P root.cmake -- foo.cmake goo.cmake
+    OUTPUT "^$")
+endsection()

--- a/test/IncludeOtherModules.cmake
+++ b/test/IncludeOtherModules.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 section("it should include modules")
   file(WRITE foo.cmake "message(STATUS \"foo\")\n")
   file(WRITE goo.cmake "message(STATUS \"goo\")\n")

--- a/test/InternalFormatMessage.cmake
+++ b/test/InternalFormatMessage.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 _assert_internal_format_message(
   MESSAGE "first line" "second line" "third line\nthird line" "fourth line\nfourth line")
 

--- a/test/SectionCreation.cmake
+++ b/test/SectionCreation.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-find_package(Assertion REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-
 section("first section")
   assert(CMAKE_MESSAGE_INDENT STREQUAL "  ")
 


### PR DESCRIPTION
This pull request resolves #120 by introducing the following changes:
- Modifies the `Assertion.cmake` module to optionally include other modules by passing additional arguments when running it as a script. This will allow test modules to be called via the `Assertion.cmake` script.
- Specifies the minimum CMake version in the `Assertion.cmake` because the minimum CMake version does not seem to work if specified in the test modules.
- Modifies test modules in this project to be called from the `Assertion.cmake` module.