### PR TITLE
Allow Section to Accept Name as Multiple Values

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -261,11 +261,14 @@ endfunction()
 
 # Begins a new test section.
 #
-# section(<name>)
+# section(<name>...)
 #
 # This function begins a new test section named `<name>`. Use the `endsection`
 # function to end the test section.
 function(section NAME)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "")
+  string(JOIN "" NAME "${NAME}" ${ARG_UNPARSED_ARGUMENTS})
+
   message(CHECK_START "${NAME}")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
   set(CMAKE_MESSAGE_INDENT "${CMAKE_MESSAGE_INDENT}" PARENT_SCOPE)

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -263,19 +263,21 @@ endfunction()
 #
 # section(<name>)
 #
-# This macro begins a new test section named `<name>`. Use the `endsection`
-# macro to end the test section.
-macro(section NAME)
+# This function begins a new test section named `<name>`. Use the `endsection`
+# function to end the test section.
+function(section NAME)
   message(CHECK_START "${NAME}")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
-endmacro()
+  set(CMAKE_MESSAGE_INDENT "${CMAKE_MESSAGE_INDENT}" PARENT_SCOPE)
+endfunction()
 
 # Ends the current test section.
 #
 # endsection()
 #
-# This macro ends the current test section and marks it as passed.
-macro(endsection)
+# This function ends the current test section and marks it as passed.
+function(endsection)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
+  set(CMAKE_MESSAGE_INDENT "${CMAKE_MESSAGE_INDENT}" PARENT_SCOPE)
   message(CHECK_PASS passed)
-endmacro()
+endfunction()

--- a/test/SectionCreation.cmake
+++ b/test/SectionCreation.cmake
@@ -10,4 +10,11 @@ section("first section")
   endsection()
 
   assert(CMAKE_MESSAGE_INDENT STREQUAL "  ")
+
+  section("third section with a very very very very very very very very very"
+    " very very very very very very very very long title" )
+    assert(CMAKE_MESSAGE_INDENT STREQUAL "  ;  ")
+  endsection()
+
+  assert(CMAKE_MESSAGE_INDENT STREQUAL "  ")
 endsection()


### PR DESCRIPTION
This pull request resolves #122 by enabling the `NAME` argument in the `section` function to accept multiple values. This change simplifies section creation, especially when the name contains a long string.