### PR TITLE
Add `ASSERTION_LIST_FILE` Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,38 +17,32 @@ if(ASSERT_ENABLE_TESTS)
 
   add_test(
     NAME "inclusion of other modules"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/IncludeOtherModules.cmake)
 
   add_test(
     NAME "condition assertions"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/Assert.cmake)
 
   add_test(
     NAME "fatal error assertions"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertFatalError.cmake)
 
   add_test(
     NAME "execute process assertions"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/AssertExecuteProcess.cmake)
 
   add_test(
     NAME "internal assertion message formatting"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/InternalFormatMessage.cmake)
 
   add_test(
     NAME "section creation"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/test/SectionCreation.cmake)
 endif()
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 3.17)
 
+# This variable contains the path to the included `Assertion.cmake` module.
+set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")
+
 # Formats an assertion message with indentation on each even line.
 #
 # _assert_internal_format_message(<out_var> [<lines>...])

--- a/test/IncludeOtherModules.cmake
+++ b/test/IncludeOtherModules.cmake
@@ -3,22 +3,19 @@ section("it should include modules")
   file(WRITE goo.cmake "message(STATUS \"goo\")\n")
 
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- foo.cmake goo.cmake
     OUTPUT ".*foo\n.*goo")
 endsection()
 
 section("it should not include any modules if arguments are not specified")
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+    COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
     OUTPUT "^$")
 endsection()
 
 section("it should not include any modules if included by another module")
-  file(WRITE root.cmake
-    "include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)\n")
+  file(WRITE root.cmake "include(\"${ASSERTION_LIST_FILE}\")\n")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -P root.cmake -- foo.cmake goo.cmake


### PR DESCRIPTION
This pull request resolves #124 by adding an `ASSERTION_LIST_FILE` variable that contains the path to the included `Assertion.cmake` file.