### PR TITLE
Fix Assert Fatal Error if No Fatal Error Received

### DIFF
--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -1,27 +1,25 @@
-section("fatal error assertions")
-  function(throw_fatal_error MESSAGE)
-    message(FATAL_ERROR "${MESSAGE}")
-  endfunction()
-
+section("it should assert a fatal error message")
   assert_fatal_error(
-    CALL throw_fatal_error "some fatal error message"
-    MESSAGE "some.*error message")
+    CALL message FATAL_ERROR "some fatal error message"
+    MESSAGE "some fa.*ror message")
+endsection()
 
-  macro(assert_fail)
+section("it should fail to assert a fatal error message")
+  macro(failed_assertion)
     assert_fatal_error(
-      CALL throw_fatal_error "some fatal error message"
-      MESSAGE "some other.*error message")
+      CALL message FATAL_ERROR "some fatal error message"
+      MESSAGE "some other fa.*ror message")
   endmacro()
 
   assert_fatal_error(
-    CALL assert_fail
+    CALL failed_assertion
     MESSAGE "expected fatal error message:\n"
       "  some fatal error message\n"
       "to match:\n"
-      "  some other.*error message")
+      "  some other fa.*ror message")
 endsection()
 
-section("mocked message check")
+section("it should be able to call the message function")
   message("some unspecified message")
   message(STATUS "some status message")
   message(STATUS "some status message" " with additional information")

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -19,6 +19,19 @@ section("it should fail to assert a fatal error message")
       "  some other fa.*ror message")
 endsection()
 
+section("it should fail to assert a fatal error message "
+  "because there is nothing to assert")
+
+  macro(failed_assertion)
+    assert_fatal_error(CALL message "some message" MESSAGE "some message")
+  endmacro()
+
+  assert_fatal_error(
+    CALL failed_assertion
+    MESSAGE "expected to receive a fatal error message that matches:\n"
+      "  some message")
+endsection()
+
 section("it should be able to call the message function")
   message("some unspecified message")
   message(STATUS "some status message")


### PR DESCRIPTION
This pull request resolves #132 by modifying the `assert_fatal_error` function to fail if it doesn't receive any fatal error message. This change also organizes tests for the fatal error assertion.