### PR TITLE
Fix Assert Fatal Error if Message Has Multiple Arguments

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -170,11 +170,11 @@ function(assert_fatal_error)
       # one or above.
       get_property(CAPTURE_LEVEL GLOBAL PROPERTY fatal_error_capture_level)
       if(CAPTURE_LEVEL GREATER_EQUAL 1 AND MODE STREQUAL FATAL_ERROR)
-        # Capture the fatal error message and decrease the level for capturing
-        # a fatal error message, indicating the requirement to capture a fatal
-        # error message is fulfilled.
-        set_property(GLOBAL PROPERTY captured_fatal_error
-          "${ARG_UNPARSED_ARGUMENTS}")
+        string(JOIN "" MESSAGE ${ARG_UNPARSED_ARGUMENTS})
+        set_property(GLOBAL PROPERTY captured_fatal_error "${MESSAGE}")
+
+        # Decrease the level for capturing a fatal error message, indicating
+        # the requirement to capture a fatal error message is fulfilled.
         math(EXPR CAPTURE_LEVEL "${CAPTURE_LEVEL} - 1")
         set_property(GLOBAL PROPERTY fatal_error_capture_level
           "${CAPTURE_LEVEL}")

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -2,6 +2,11 @@ section("it should assert a fatal error message")
   assert_fatal_error(
     CALL message FATAL_ERROR "some fatal error message"
     MESSAGE "some fa.*ror message")
+
+  assert_fatal_error(
+    CALL message FATAL_ERROR "some fatal error message "
+      "with additional message"
+    MESSAGE "some fa.*ror message with additional message")
 endsection()
 
 section("it should fail to assert a fatal error message")

--- a/test/AssertFatalError.cmake
+++ b/test/AssertFatalError.cmake
@@ -36,9 +36,3 @@ section("it should fail to assert a fatal error message "
     MESSAGE "expected to receive a fatal error message that matches:\n"
       "  some message")
 endsection()
-
-section("it should be able to call the message function")
-  message("some unspecified message")
-  message(STATUS "some status message")
-  message(STATUS "some status message" " with additional information")
-endsection()


### PR DESCRIPTION
This pull request resolves #136 by fixing the mocked `message` function in the `assert_fatal_error` function to correctly format the captured fatal error message when the `message` function is called with multiple arguments.

It also removes the unnecessary `message` function call tests because calls to the `message` function with multiple arguments are implicitly already covered in other tests.