### PR TITLE
Modify Name to Be Optional When Adding CMake Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,17 +16,17 @@ if(ASSERT_ENABLE_TESTS)
   enable_testing()
 
   assertion_add_test(
-    "inclusion of other modules" test/IncludeOtherModules.cmake)
+    test/IncludeOtherModules.cmake NAME "inclusion of other modules")
 
-  assertion_add_test("test creation" test/TestCreation.cmake)
-  assertion_add_test("failure invocation" test/Fail.cmake)
-  assertion_add_test("condition assertions" test/Assert.cmake)
-  assertion_add_test("fatal error assertions" test/AssertFatalError.cmake)
+  assertion_add_test(test/TestCreation.cmake NAME "test creation")
+  assertion_add_test(test/Fail.cmake NAME "failure invocation")
+  assertion_add_test(test/Assert.cmake NAME "condition assertions")
+  assertion_add_test(test/AssertFatalError.cmake NAME "fatal error assertions")
 
   assertion_add_test(
-    "execute process assertions" test/AssertExecuteProcess.cmake)
+    test/AssertExecuteProcess.cmake NAME "execute process assertions")
 
-  assertion_add_test("section creation" test/SectionCreation.cmake)
+  assertion_add_test(test/SectionCreation.cmake NAME "section creation")
 endif()
 
 if(ASSERT_ENABLE_INSTALL)

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -8,13 +8,20 @@ set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")
 
 # Add a new test that runs a CMake file in script mode.
 #
-# assertion_add_test(<name> <file>)
+# assertion_add_test(<file> [NAME <name>])
 #
-# This function adds a new test named `<name>` that will run the specified
-# `<file>` CMake file in script mode.
-function(assertion_add_test NAME FILE)
+# This function adds a new test that will run the specified `<file>` CMake file
+# in script mode. If `<name>` is specified, it will use that as the test name;
+# otherwise, it will use `<file>` instead.
+function(assertion_add_test FILE)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" NAME "")
+
+  if(NOT DEFINED ARG_NAME)
+    set(ARG_NAME "${FILE}")
+  endif()
+
   add_test(
-    NAME "${NAME}"
+    NAME "${ARG_NAME}"
     COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
       -- ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
 endfunction()

--- a/test/TestCreation.cmake
+++ b/test/TestCreation.cmake
@@ -1,6 +1,18 @@
 section("it should correctly create a new test")
   function(add_test)
-    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "NAME" "COMMAND")
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" COMMAND)
+
+    set(EXPECTED_COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
+      -- ${CMAKE_CURRENT_SOURCE_DIR}/some_test.cmake)
+    assert(ARG_COMMAND STREQUAL EXPECTED_COMMAND)
+  endfunction()
+
+  assertion_add_test(some_test.cmake)
+endsection()
+
+section("it should correctly create a new test with the name specified")
+  function(add_test)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" NAME COMMAND)
     assert(ARG_NAME STREQUAL "some test")
 
     set(EXPECTED_COMMAND "${CMAKE_COMMAND}" -P "${ASSERTION_LIST_FILE}"
@@ -8,5 +20,5 @@ section("it should correctly create a new test")
     assert(ARG_COMMAND STREQUAL EXPECTED_COMMAND)
   endfunction()
 
-  assertion_add_test("some test" some_test.cmake)
+  assertion_add_test(some_test.cmake NAME "some test")
 endsection()


### PR DESCRIPTION
This pull request resolves #142 by modifying the `NAME` argument in the `assertion_add_test` function to be optional, defaulting the test name to the file name if the `NAME` option is not specified.