### PR TITLE
Allow Fail Function to Expand Twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ This macro throws a fatal error message formatted from the given `<lines>`.
 
 It formats the message by concatenating all the lines into a single message. If
 one of the lines is a variable, it will be expanded and indented by two spaces
-before being concatenated with the other lines.
+before being concatenated with the other lines. If the expanded variable is
+another variable, it will format both the name and the value of the other
+variable.
 
 #### Example
 

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -427,13 +427,13 @@ section("string equality condition assertions")
       assert_fatal_error(
         CALL assert NOT "some string" STREQUAL STRING_VAR
         MESSAGE "expected string:\n  some string\n"
-          "not to be equal to string:\n  some string\n"
+          "not to be equal to:\n  some string\n"
           "of variable:\n  STRING_VAR")
 
       assert_fatal_error(
         CALL assert "some string" STREQUAL OTHER_STRING_VAR
         MESSAGE "expected string:\n  some string\n"
-          "to be equal to string:\n  some other string\n"
+          "to be equal to:\n  some other string\n"
           "of variable:\n  OTHER_STRING_VAR")
     endsection()
   endsection()
@@ -470,14 +470,14 @@ section("string equality condition assertions")
         CALL assert NOT STRING_VAR STREQUAL STRING_VAR
         MESSAGE "expected string:\n  some string\n"
           "of variable:\n  STRING_VAR\n"
-          "not to be equal to string:\n  some string\n"
+          "not to be equal to:\n  some string\n"
           "of variable:\n  STRING_VAR")
 
       assert_fatal_error(
         CALL assert STRING_VAR STREQUAL OTHER_STRING_VAR
         MESSAGE "expected string:\n  some string\n"
           "of variable:\n  STRING_VAR\n"
-          "to be equal to string:\n  some other string\n"
+          "to be equal to:\n  some other string\n"
           "of variable:\n  OTHER_STRING_VAR")
     endsection()
   endsection()

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -417,48 +417,6 @@ section("string equality condition assertions")
     endsection()
   endsection()
 
-  section("given a string and a variable")
-    section("it should assert string equality conditions")
-      assert("some string" STREQUAL STRING_VAR)
-      assert(NOT "some string" STREQUAL OTHER_STRING_VAR)
-    endsection()
-
-    section("it should fail to assert string equality conditions")
-      assert_fatal_error(
-        CALL assert NOT "some string" STREQUAL STRING_VAR
-        MESSAGE "expected string:\n  some string\n"
-          "not to be equal to:\n  some string\n"
-          "of variable:\n  STRING_VAR")
-
-      assert_fatal_error(
-        CALL assert "some string" STREQUAL OTHER_STRING_VAR
-        MESSAGE "expected string:\n  some string\n"
-          "to be equal to:\n  some other string\n"
-          "of variable:\n  OTHER_STRING_VAR")
-    endsection()
-  endsection()
-
-  section("given a variable and a string")
-    section("it should assert string equality conditions")
-      assert(STRING_VAR STREQUAL "some string")
-      assert(NOT STRING_VAR STREQUAL "some other string")
-    endsection()
-
-    section("it should fail to assert string equality conditions")
-      assert_fatal_error(
-        CALL assert NOT STRING_VAR STREQUAL "some string"
-        MESSAGE "expected string:\n  some string\n"
-          "of variable:\n  STRING_VAR\n"
-          "not to be equal to:\n  some string")
-
-      assert_fatal_error(
-        CALL assert STRING_VAR STREQUAL "some other string"
-        MESSAGE "expected string:\n  some string\n"
-          "of variable:\n  STRING_VAR\n"
-          "to be equal to:\n  some other string")
-    endsection()
-  endsection()
-
   section("given variables")
     section("it should assert string equality conditions")
       assert(STRING_VAR STREQUAL STRING_VAR)

--- a/test/fail.cmake
+++ b/test/fail.cmake
@@ -16,6 +16,7 @@ endsection()
 
 set(SINGLE "single line variable")
 set(MULTIPLE "multiple\nlines\nvariable")
+set(CONTAINS_SINGLE SINGLE)
 
 section("given variables")
   section("it should fail with a formatted fatal error message")
@@ -28,8 +29,17 @@ section("given variables")
       MESSAGE "multiple\nlines\nvariable")
 
     assert_fatal_error(
+      CALL fail CONTAINS_SINGLE
+      MESSAGE "single line variable\nof variable:\n  SINGLE")
+
+    assert_fatal_error(
       CALL fail SINGLE MULTIPLE
       MESSAGE "single line variable\nmultiple\nlines\nvariable")
+
+    assert_fatal_error(
+      CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
+      MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+        "single line variable\nof variable:\n  SINGLE")
   endsection()
 endsection()
 
@@ -52,13 +62,27 @@ section("given strings and variables")
       MESSAGE "multiple\nlines\nvariable\nmultiple\nlines\nstring")
 
     assert_fatal_error(
-      CALL fail "single line string" "multiple\nlines\nstring" SINGLE MULTIPLE
-      MESSAGE "single line string\nmultiple\nlines\nstring:\n"
-        "  single line variable\n  multiple\n  lines\n  variable")
+      CALL fail "single line string" CONTAINS_SINGLE
+      MESSAGE "single line string:\n  single line variable\n"
+        "of variable:\n  SINGLE")
 
     assert_fatal_error(
-      CALL fail SINGLE MULTIPLE "single line string" "multiple\nlines\nstring"
+      CALL fail CONTAINS_SINGLE "single line string"
+      MESSAGE "single line variable\nof variable:\n  SINGLE\n"
+        "single line string")
+
+    assert_fatal_error(
+      CALL fail "single line string" "multiple\nlines\nstring"
+        SINGLE MULTIPLE CONTAINS_SINGLE
+      MESSAGE "single line string\nmultiple\nlines\nstring:\n"
+        "  single line variable\n  multiple\n  lines\n  variable\n"
+        "  single line variable\nof variable:\n  SINGLE")
+
+    assert_fatal_error(
+      CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
+        "single line string" "multiple\nlines\nstring"
       MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+        "single line variable\nof variable:\n  SINGLE\n"
         "single line string\nmultiple\nlines\nstring")
 
     assert_fatal_error(


### PR DESCRIPTION
This pull request resolves #188 by allowing the `fail` function to expand the given line twice if the line is a variable that contains another variable. It also minimizes the test cases for the string equality assertion.