### PR TITLE
Explain Assert Function Internally Uses If Function in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ This function performs an assertion on the given `<condition>`. If the assertion
 fails, it will output a formatted fatal error message with information about the
 context of the asserted condition.
 
-Refer to the documentation of CMake's
-[`if`](https://cmake.org/cmake/help/latest/command/if.html) function for more
-information about supported conditions for the assertion.
+Internally, this function uses CMake's `if` function to check the given
+condition and throws a fatal error message if the condition resolves to false.
+Refer to the
+[CMake's `if` function documentation](https://cmake.org/cmake/help/latest/command/if.html)
+for more information about supported conditions for the assertion.
 
 #### Example
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -103,7 +103,9 @@ endmacro()
 # assertion fails, it will output a formatted fatal error message with
 # information about the context of the asserted condition.
 #
-# Refer to the documentation of CMake's `if` function for more information about
+# Internally, this function uses CMake's `if` function to check the given
+# condition and throws a fatal error message if the condition resolves to false.
+# Refer to the CMake's `if` function documentation for more information about
 # supported conditions for the assertion.
 function(assert)
   cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "")


### PR DESCRIPTION
This pull request updates the documentation for the `assert` function, explaining that it internally uses CMake's `if` function to check the assertion condition.