### PR TITLE
Add Support for Formatting Path Equality Assertion Errors

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -37,7 +37,7 @@
 # modules by passing the paths of the other modules as additional arguments
 # after `--`.
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.24)
 
 # This variable contains the path to the included `Assertion.cmake` module.
 set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")
@@ -238,6 +238,9 @@ function(assert)
       elseif(ARGV1 STREQUAL "STREQUAL")
         fail("expected string" ARGV0 "to be equal to" ARGV2)
         return()
+      elseif(ARGV1 STREQUAL "PATH_EQUAL")
+        fail("expected path" ARGV0 "to be equal to" ARGV2)
+        return()
       endif()
     endif()
   elseif(ARGC EQUAL 4)
@@ -250,6 +253,9 @@ function(assert)
         return()
       elseif(ARGV2 STREQUAL "STREQUAL")
         fail("expected string" ARGV1 "not to be equal to" ARGV3)
+        return()
+      elseif(ARGV2 STREQUAL "PATH_EQUAL")
+        fail("expected path" ARGV1 "not to be equal to" ARGV3)
         return()
       endif()
     endif()

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -440,3 +440,51 @@ section("string equality condition assertions")
     endsection()
   endsection()
 endsection()
+
+section("path equality condition assertions")
+  section("given strings")
+    section("it should assert path equality conditions")
+      assert("/some/path" PATH_EQUAL "/some//path")
+      assert(NOT "/some/path" PATH_EQUAL "/some/other/path")
+    endsection()
+
+    section("it should fail to assert path equality conditions")
+      assert_fatal_error(
+        CALL assert "/some/path" PATH_EQUAL "/some/other/path"
+        MESSAGE "expected path:\n  /some/path\n"
+          "to be equal to:\n  /some/other/path")
+
+      assert_fatal_error(
+        CALL assert NOT "/some/path" PATH_EQUAL "/some//path"
+        MESSAGE "expected path:\n  /some/path\n"
+          "not to be equal to:\n  /some//path")
+    endsection()
+  endsection()
+
+  section("given variables")
+    set(PATH_VAR "/some/path")
+    set(PATHH_VAR "/some//path")
+    set(OTHER_PATH_VAR "/some/other/path")
+
+    section("it should assert path equality conditions")
+      assert(PATH_VAR PATH_EQUAL PATHH_VAR)
+      assert(NOT PATH_VAR PATH_EQUAL OTHER_PATH_VAR)
+    endsection()
+
+    section("it should fail to assert path equality conditions")
+      assert_fatal_error(
+        CALL assert PATH_VAR PATH_EQUAL OTHER_PATH_VAR
+        MESSAGE "expected path:\n  /some/path\n"
+          "of variable:\n  PATH_VAR\n"
+          "to be equal to:\n  /some/other/path\n"
+          "of variable:\n  OTHER_PATH_VAR")
+
+      assert_fatal_error(
+        CALL assert NOT PATH_VAR PATH_EQUAL PATHH_VAR
+        MESSAGE "expected path:\n  /some/path\n"
+          "of variable:\n  PATH_VAR\n"
+          "not to be equal to:\n  /some//path\n"
+          "of variable:\n  PATHH_VAR")
+    endsection()
+  endsection()
+endsection()


### PR DESCRIPTION
This pull request resolves #197 by updating the `assert` function to support formatting errors related to path equality assertions. It also adds tests to validate that functionality and bumps the minimum CMake version of the `Assertion.cmake` module to the version 3.24.