### PR TITLE
Update Module Integration Guide to Use Expected Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ during the project configuration using the
 function:
 
 ```cmake
-file(DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-  ${CMAKE_BINARY_DIR}/Assertion.cmake)
+file(
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+    ${CMAKE_BINARY_DIR}/Assertion.cmake
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 ```
 


### PR DESCRIPTION
This pull request resolves #221 by updating the module integration guide to use the expected hash for downloading the `Assertion.cmake` module, preventing the module from being redownloaded every time the project build is configured.