### PR TITLE
Add Module Version Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   Assertion
-  VERSION 1.0.0
+  VERSION 1.1.0
   DESCRIPTION "A collection of assertion functions and other utilities for testing CMake code"
   HOMEPAGE_URL https://github.com/threeal/assertion-cmake
   LANGUAGES NONE)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ the `git_checkout_test.cmake` file.
 
 ## API Reference
 
+### `ASSERTION_VERSION`
+
+This variable contains the version of the included `Assertion.cmake` module.
+
 ### `ASSERTION_LIST_FILE`
 
 This variable contains the path to the included `Assertion.cmake` module.

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -38,7 +38,7 @@
 # after `--`.
 
 # This variable contains the version of the included `Assertion.cmake` module.
-set(ASSERTION_VERSION 1.0.0)
+set(ASSERTION_VERSION 1.1.0)
 
 # This variable contains the path to the included `Assertion.cmake` module.
 set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -37,6 +37,9 @@
 # modules by passing the paths of the other modules as additional arguments
 # after `--`.
 
+# This variable contains the version of the included `Assertion.cmake` module.
+set(ASSERTION_VERSION 1.0.0)
+
 # This variable contains the path to the included `Assertion.cmake` module.
 set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")
 


### PR DESCRIPTION
This pull request resolves #225 by adding a new `ASSERTION_VERSION` variable that contains the version of the included `Assertion.cmake` module. It also bumps the project version to 1.1.0.