### PR TITLE
Fix Handle Empty String Arguments in Assert Function

### DIFF
--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -30,6 +30,7 @@ function(assert_configure_sample_project FIRST_CODE)
 endfunction()
 
 section("boolean condition assertions")
+
   section("it should assert boolean conditions")
     assert(TRUE)
     assert(NOT FALSE)


### PR DESCRIPTION
This pull request resolves #227.

TODO:
- [ ] handle empty string arguments.