### PR TITLE
Remove List File Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,6 @@ process the `git_checkout_test.cmake` file in script mode.
 
 This variable contains the version of the included `Assertion.cmake` module.
 
-### `ASSERTION_LIST_FILE`
-
-This variable contains the path to the included `Assertion.cmake` module.
-
 ### `add_cmake_script_test`
 
 Adds a new test that processes the given CMake file in script mode.

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -39,9 +39,6 @@
 # This variable contains the version of the included `Assertion.cmake` module.
 set(ASSERTION_VERSION 2.0.0)
 
-# This variable contains the path to the included `Assertion.cmake` module.
-set(ASSERTION_LIST_FILE "${CMAKE_CURRENT_LIST_FILE}")
-
 # Adds a new test that processes the given CMake file in script mode.
 #
 # add_cmake_script_test(<file> [NAME <name>])

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -1,4 +1,5 @@
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+  RESULT_VARIABLE ASSERTION_LIST_FILE)
 
 # Asserts whether the given code of a sample project can be configured
 # successfully.

--- a/test/include.cmake
+++ b/test/include.cmake
@@ -1,4 +1,5 @@
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
+  RESULT_VARIABLE ASSERTION_LIST_FILE)
 
 section("it should include modules")
   file(WRITE foo.cmake "message(STATUS \"foo\")\n")


### PR DESCRIPTION
This pull request resolves #231 by removing the `ASSERTION_LIST_FILE` variable from the `Assertion.cmake` module.