### PR TITLE
Assert File Exists Before Adding CMake Script Test

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -50,6 +50,10 @@ function(add_cmake_script_test FILE)
   endif()
 
   cmake_path(ABSOLUTE_PATH FILE)
+  if(NOT EXISTS ${FILE})
+    message(SEND_ERROR "Cannot find test file:\n  ${FILE}")
+  endif()
+
   add_test(NAME "${ARG_NAME}" COMMAND "${CMAKE_COMMAND}" -P ${FILE})
 endfunction()
 

--- a/test/add_cmake_script_test.cmake
+++ b/test/add_cmake_script_test.cmake
@@ -50,4 +50,19 @@ section("it should create a new test with the specified name")
     ctest --test-dir project/build -R "^a test$" --no-tests=error)
 endsection()
 
+section("it should fail to create a new test due to a non-existing file")
+  file(WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.21)\n"
+    "project(Sample LANGUAGES NONE)\n"
+    "\n"
+    "include(${ASSERTION_LIST_FILE})\n"
+    "\n"
+    "enable_testing()\n"
+    "add_cmake_script_test(invalid.cmake)\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" --fresh -S project -B project/build
+    ERROR "Cannot find test file:.*invalid.cmake")
+endsection()
+
 file(REMOVE_RECURSE project)


### PR DESCRIPTION
This pull request resolves #235 by updating the `add_cmake_script_test` function to assert the existence of the specified test file before adding a new test, ensuring that the test file is present before running the tests.