### PR TITLE
Add Support to Specify Test File Using Absolute Path

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -49,9 +49,8 @@ function(add_cmake_script_test FILE)
     set(ARG_NAME "${FILE}")
   endif()
 
-  add_test(
-    NAME "${ARG_NAME}"
-    COMMAND "${CMAKE_COMMAND}" -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+  cmake_path(ABSOLUTE_PATH FILE)
+  add_test(NAME "${ARG_NAME}" COMMAND "${CMAKE_COMMAND}" -P ${FILE})
 endfunction()
 
 # Throws a formatted fatal error message.

--- a/test/add_cmake_script_test.cmake
+++ b/test/add_cmake_script_test.cmake
@@ -1,24 +1,37 @@
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 
-section("it should correctly create a new test")
+section("it should create a new test")
   function(add_test)
     cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" COMMAND)
 
     set(EXPECTED_COMMAND "${CMAKE_COMMAND}" -P
-      ${CMAKE_CURRENT_SOURCE_DIR}/some_test.cmake)
+      ${CMAKE_CURRENT_BINARY_DIR}/some_test.cmake)
     assert(ARG_COMMAND STREQUAL EXPECTED_COMMAND)
   endfunction()
 
   add_cmake_script_test(some_test.cmake)
 endsection()
 
-section("it should correctly create a new test with the name specified")
+section("it should create a new test "
+  "with the file specified using an absolute path")
+  function(add_test)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" COMMAND)
+
+    set(EXPECTED_COMMAND "${CMAKE_COMMAND}" -P
+      ${CMAKE_CURRENT_BINARY_DIR}/some_test.cmake)
+    assert(ARG_COMMAND STREQUAL EXPECTED_COMMAND)
+  endfunction()
+
+  add_cmake_script_test(${CMAKE_CURRENT_BINARY_DIR}/some_test.cmake)
+endsection()
+
+section("it should create a new test with the specified name")
   function(add_test)
     cmake_parse_arguments(PARSE_ARGV 0 ARG "" NAME COMMAND)
     assert(ARG_NAME STREQUAL "some test")
 
     set(EXPECTED_COMMAND "${CMAKE_COMMAND}" -P
-      ${CMAKE_CURRENT_SOURCE_DIR}/some_test.cmake)
+      ${CMAKE_CURRENT_BINARY_DIR}/some_test.cmake)
     assert(ARG_COMMAND STREQUAL EXPECTED_COMMAND)
   endfunction()
 


### PR DESCRIPTION
This pull request resolves #237 by updating the `add_cmake_script_test` function to support specifying the test file using an absolute path.