### PR TITLE
Add CPack Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,13 +15,12 @@ jobs:
       - name: Configure Project
         run: cmake --preset default
 
-      - name: Install Project
-        run: cmake --install build --prefix install
+      - name: Package Project
+        run: cpack --preset default
 
       - name: Upload Project
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: Assertion
-          path: install
+          path: build/*.tar.gz
           if-no-files-found: error
           overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 !.git*
 
 build
-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,7 @@ if(ASSERTION_ENABLE_INSTALL)
       cmake/AssertionConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/AssertionConfigVersion.cmake
     DESTINATION lib/cmake/Assertion)
+
+  set(CPACK_SYSTEM_NAME any)
+  include(CPack)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21
+    "minor": 25
   },
   "configurePresets": [
     {
@@ -27,6 +27,13 @@
       "execution": {
         "noTestsAction": "error"
       }
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "generators": ["TGZ"]
     }
   ]
 }


### PR DESCRIPTION
This pull request resolves #253 by adding CPack support to the project, which includes a new `default` package preset and updates the workflow to package the project instead of installing it. It also removes the `install` directory from the Git ignore list.