### PR TITLE
Prefix Expect Options in Assert Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ assert_execute_process(
 
 assert_fatal_error(
   CALL git_clone https://github.com GITHUB_DIR
-  MESSAGE "failed to clone 'https://github.com'")
+  EXPECT_MESSAGE "failed to clone 'https://github.com'")
 ```
 
 ### Test Creation
@@ -174,7 +174,8 @@ to be defined
 Asserts whether a command call throws a fatal error message.
 
 ```cmake
-assert_fatal_error(CALL <command> [<arguments>...] MESSAGE <message>...)
+assert_fatal_error(
+  CALL <command> [<arguments>...] EXPECT_MESSAGE <message>...)
 ```
 
 This function asserts whether a function or macro named `<command>`, called with the specified `<arguments>`, throws a fatal error message that matches the expected `<message>`.
@@ -190,7 +191,7 @@ endfunction()
 
 assert_fatal_error(
   CALL throw_fatal_error "some message"
-  MESSAGE "some message")
+  EXPECT_MESSAGE "some message")
 ```
 
 The above example asserts whether the call to `throw_fatal_error("some message")` throws a fatal error message that matches `some message`. If it somehow does not capture any fatal error message, it will throw the following fatal error message:

--- a/README.md
+++ b/README.md
@@ -208,13 +208,13 @@ Asserts whether the given command correctly executes a process.
 ```cmake
 assert_execute_process(
   [COMMAND] <command> [<arguments>...]
-  [OUTPUT <output>...]
+  [EXPECT_OUTPUT <output>...]
   [ERROR <error>...])
 ```
 
 This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `ERROR` is specified, it instead asserts whether it fails to execute the process.
 
-If `OUTPUT` is specified, it also asserts whether the output of the executed process matches the expected `<output>`. If more than one `<output>` string is given, they are concatenated into a single output with no separator between the strings.
+If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the executed process matches the expected `<output>`. If more than one `<output>` string is given, they are concatenated into a single output with no separator between the strings.
 
 If `ERROR` is specified, it also asserts whether the error of the executed process matches the expected `<error>`. If more than one `<error>` string is given, they are concatenated into a single error with no separator between the strings.
 
@@ -223,7 +223,7 @@ If `ERROR` is specified, it also asserts whether the error of the executed proce
 ```cmake
 assert_execute_process(
   COMMAND ${CMAKE_COMMAND} -E echo hello
-  OUTPUT hello)
+  EXPECT_OUTPUT hello)
 ```
 
 The above example asserts whether the call to `${CMAKE_COMMAND} -E echo hello` successfully executes a process whose output matches `hello`. If it somehow fails to execute the process, it will throw the following fatal error message:

--- a/README.md
+++ b/README.md
@@ -209,14 +209,14 @@ Asserts whether the given command correctly executes a process.
 assert_execute_process(
   [COMMAND] <command> [<arguments>...]
   [EXPECT_OUTPUT <output>...]
-  [ERROR <error>...])
+  [EXPECT_ERROR <error>...])
 ```
 
-This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `ERROR` is specified, it instead asserts whether it fails to execute the process.
+This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `EXPECT_ERROR` is specified, it instead asserts whether it fails to execute the process.
 
 If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the executed process matches the expected `<output>`. If more than one `<output>` string is given, they are concatenated into a single output with no separator between the strings.
 
-If `ERROR` is specified, it also asserts whether the error of the executed process matches the expected `<error>`. If more than one `<error>` string is given, they are concatenated into a single error with no separator between the strings.
+If `EXPECT_ERROR` is specified, it also asserts whether the error of the executed process matches the expected `<error>`. If more than one `<error>` string is given, they are concatenated into a single error with no separator between the strings.
 
 #### Example
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -429,24 +429,24 @@ endfunction()
 #
 # assert_execute_process(
 #   [COMMAND] <command> [<arguments>...]
-#   [OUTPUT <output>...]
+#   [EXPECT_OUTPUT <output>...]
 #   [ERROR <error>...])
 #
 # This function asserts whether the given `<command>` and `<arguments>`
 # successfully execute a process. If `ERROR` is specified, it instead asserts
 # whether it fails to execute the process.
 #
-# If `OUTPUT` is specified, it also asserts whether the output of the executed
-# process matches the expected `<output>`. If more than one `<output>` string
-# is given, they are concatenated into a single output with no separator between
-# the strings.
+# If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the
+# executed process matches the expected `<output>`. If more than one `<output>`
+# string is given, they are concatenated into a single output with no separator
+# between the strings.
 #
 # If `ERROR` is specified, it also asserts whether the error of the executed
 # process matches the expected `<error>`. If more than one `<error>` string
 # is given, they are concatenated into a single error with no separator between
 # the strings.
 function(assert_execute_process)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "COMMAND;OUTPUT;ERROR")
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "COMMAND;EXPECT_OUTPUT;ERROR")
 
   if(NOT DEFINED ARG_COMMAND)
     set(ARG_COMMAND ${ARG_UNPARSED_ARGUMENTS})
@@ -472,8 +472,8 @@ function(assert_execute_process)
     endif()
   endif()
 
-  if(DEFINED ARG_OUTPUT)
-    string(JOIN "" EXPECTED_OUTPUT ${ARG_OUTPUT})
+  if(DEFINED ARG_EXPECT_OUTPUT)
+    string(JOIN "" EXPECTED_OUTPUT ${ARG_EXPECT_OUTPUT})
     if(NOT "${OUT}" MATCHES "${EXPECTED_OUTPUT}")
       string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
       fail("expected the output" OUT "of command" COMMAND

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -349,7 +349,8 @@ endfunction()
 
 # Asserts whether a command call throws a fatal error message.
 #
-# assert_fatal_error(CALL <command> [<arguments>...] MESSAGE <message>...)
+# assert_fatal_error(
+#   CALL <command> [<arguments>...] EXPECT_MESSAGE <message>...)
 #
 # This function asserts whether a function or macro named `<command>`, called
 # with the specified `<arguments>`, throws a fatal error message that matches
@@ -358,8 +359,8 @@ endfunction()
 # If more than one `<message>` string is given, they are concatenated into a
 # single message with no separator between the strings.
 function(assert_fatal_error)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;MESSAGE")
-  string(JOIN "" EXPECTED_MESSAGE ${ARG_MESSAGE})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;EXPECT_MESSAGE")
+  string(JOIN "" EXPECTED_MESSAGE ${ARG_EXPECT_MESSAGE})
 
   # Override the `message` function if it has not been overridden.
   get_property(MESSAGE_MOCKED GLOBAL PROPERTY _assert_internal_message_mocked)

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -430,23 +430,24 @@ endfunction()
 # assert_execute_process(
 #   [COMMAND] <command> [<arguments>...]
 #   [EXPECT_OUTPUT <output>...]
-#   [ERROR <error>...])
+#   [EXPECT_ERROR <error>...])
 #
 # This function asserts whether the given `<command>` and `<arguments>`
-# successfully execute a process. If `ERROR` is specified, it instead asserts
-# whether it fails to execute the process.
+# successfully execute a process. If `EXPECT_ERROR` is specified, it instead
+# asserts whether it fails to execute the process.
 #
 # If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the
 # executed process matches the expected `<output>`. If more than one `<output>`
 # string is given, they are concatenated into a single output with no separator
 # between the strings.
 #
-# If `ERROR` is specified, it also asserts whether the error of the executed
-# process matches the expected `<error>`. If more than one `<error>` string
-# is given, they are concatenated into a single error with no separator between
-# the strings.
+# If `EXPECT_ERROR` is specified, it also asserts whether the error of the
+# executed process matches the expected `<error>`. If more than one `<error>`
+# string is given, they are concatenated into a single error with no separator
+# between the strings.
 function(assert_execute_process)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "COMMAND;EXPECT_OUTPUT;ERROR")
+  cmake_parse_arguments(
+    PARSE_ARGV 0 ARG "" "" "COMMAND;EXPECT_OUTPUT;EXPECT_ERROR")
 
   if(NOT DEFINED ARG_COMMAND)
     set(ARG_COMMAND ${ARG_UNPARSED_ARGUMENTS})
@@ -458,7 +459,7 @@ function(assert_execute_process)
     OUTPUT_VARIABLE OUT
     ERROR_VARIABLE ERR)
 
-  if(DEFINED ARG_ERROR)
+  if(DEFINED ARG_EXPECT_ERROR)
     if(RES EQUAL 0)
       string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
       fail("expected command" COMMAND "to fail")
@@ -482,8 +483,8 @@ function(assert_execute_process)
     endif()
   endif()
 
-  if(DEFINED ARG_ERROR)
-    string(JOIN "" EXPECTED_ERROR ${ARG_ERROR})
+  if(DEFINED ARG_EXPECT_ERROR)
+    string(JOIN "" EXPECTED_ERROR ${ARG_EXPECT_ERROR})
     if(NOT "${ERR}" MATCHES "${EXPECTED_ERROR}")
       string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
       fail("expected the error" ERR "of command" COMMAND

--- a/test/add_cmake_script_test.cmake
+++ b/test/add_cmake_script_test.cmake
@@ -60,7 +60,7 @@ file(REMOVE project/test.cmake)
 section("it should fail to create a new test due to a non-existent file")
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" --fresh -S project -B project/build
-    ERROR "Cannot find test file:.*test.cmake")
+    EXPECT_ERROR "Cannot find test file:.*test.cmake")
 endsection()
 
 file(REMOVE_RECURSE project)

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -43,11 +43,11 @@ section("boolean condition assertions")
   section("it should fail to assert boolean conditions")
     assert_fatal_error(
       CALL assert FALSE
-      MESSAGE "expected:\n  FALSE\nto resolve to true")
+      EXPECT_MESSAGE "expected:\n  FALSE\nto resolve to true")
 
     assert_fatal_error(
       CALL assert NOT TRUE
-      MESSAGE "expected:\n  NOT TRUE\nto resolve to true")
+      EXPECT_MESSAGE "expected:\n  NOT TRUE\nto resolve to true")
   endsection()
 endsection()
 
@@ -63,11 +63,11 @@ section("command existence condition assertions")
   section("it should fail to assert command existence conditions")
     assert_fatal_error(
       CALL assert COMMAND non_existing_command
-      MESSAGE "expected command:\n  non_existing_command\nto be defined")
+      EXPECT_MESSAGE "expected command:\n  non_existing_command\nto be defined")
 
     assert_fatal_error(
       CALL assert NOT COMMAND existing_command
-      MESSAGE "expected command:\n  existing_command\nnot to be defined")
+      EXPECT_MESSAGE "expected command:\n  existing_command\nnot to be defined")
   endsection()
 endsection()
 
@@ -80,11 +80,11 @@ section("policy existence condition assertions")
   section("it should fail to assert policy existence conditions")
     assert_fatal_error(
       CALL assert POLICY CMPXXXX
-      MESSAGE "expected policy:\n  CMPXXXX\nto exist")
+      EXPECT_MESSAGE "expected policy:\n  CMPXXXX\nto exist")
 
     assert_fatal_error(
       CALL assert NOT POLICY CMP0000
-      MESSAGE "expected policy:\n  CMP0000\nnot to exist")
+      EXPECT_MESSAGE "expected policy:\n  CMP0000\nnot to exist")
   endsection()
 endsection()
 
@@ -105,11 +105,13 @@ section("target existence condition assertions")
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert TARGET non_existing_target\n"
-      "  MESSAGE \"expected target:\\n  non_existing_target\\nto exist\")\n"
+      "  EXPECT_MESSAGE \"expected target:\\n  non_existing_target\\n\"\n"
+      "    \"to exist\")\n"
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert NOT TARGET some_target\n"
-      "  MESSAGE \"expected target:\\n  some_target\\nnot to exist\")\n")
+      "  EXPECT_MESSAGE \"expected target:\\n  some_target\\n\"\n"
+      "    \"not to exist\")\n")
   endsection()
 endsection()
 
@@ -130,11 +132,11 @@ section("test existence condition assertions")
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert TEST non_existing_test\n"
-      "  MESSAGE \"expected test:\\n  non_existing_test\\nto exist\")\n"
+      "  EXPECT_MESSAGE \"expected test:\\n  non_existing_test\\nto exist\")\n"
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert NOT TEST some_test\n"
-      "  MESSAGE \"expected test:\\n  some_test\\nnot to exist\")\n")
+      "  EXPECT_MESSAGE \"expected test:\\n  some_test\\nnot to exist\")\n")
   endsection()
 endsection()
 
@@ -150,11 +152,13 @@ section("variable existence condition assertions")
   section("it should fail to assert variable existence conditions")
     assert_fatal_error(
       CALL assert DEFINED NON_EXISTING_VARIABLE
-      MESSAGE "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined")
+      EXPECT_MESSAGE "expected variable:\n  NON_EXISTING_VARIABLE\n"
+        "to be defined")
 
     assert_fatal_error(
       CALL assert NOT DEFINED EXISTING_VARIABLE
-      MESSAGE "expected variable:\n  EXISTING_VARIABLE\nnot to be defined")
+      EXPECT_MESSAGE "expected variable:\n  EXISTING_VARIABLE\n"
+        "not to be defined")
   endsection()
 endsection()
 
@@ -175,13 +179,13 @@ section("list element existence condition assertions")
   section("it should fail to assert list element existence conditions")
     assert_fatal_error(
       CALL assert "other element" IN_LIST SOME_LIST
-      MESSAGE "expected string:\n  other element\n"
+      EXPECT_MESSAGE "expected string:\n  other element\n"
         "to exist in:\n  some element;some other element\n"
         "of variable:\n  SOME_LIST")
 
     assert_fatal_error(
       CALL assert NOT "some element" IN_LIST SOME_LIST
-      MESSAGE "expected string:\n  some element\n"
+      EXPECT_MESSAGE "expected string:\n  some element\n"
         "not to exist in:\n  some element;some other element\n"
         "of variable:\n  SOME_LIST")
   endsection()
@@ -199,11 +203,11 @@ section("path existence condition assertions")
   section("it should fail to assert path existence conditions")
     assert_fatal_error(
       CALL assert EXISTS non_existing_file
-      MESSAGE "expected path:\n  non_existing_file\nto exist")
+      EXPECT_MESSAGE "expected path:\n  non_existing_file\nto exist")
 
     assert_fatal_error(
       CALL assert NOT EXISTS some_file
-      MESSAGE "expected path:\n  some_file\nnot to exist")
+      EXPECT_MESSAGE "expected path:\n  some_file\nnot to exist")
   endsection()
 endsection()
 
@@ -222,11 +226,11 @@ section("path readability condition assertions")
   section("it should fail to assert path readability conditions")
     assert_fatal_error(
       CALL assert IS_READABLE non_readable_file
-      MESSAGE "expected path:\n  non_readable_file\nto be readable")
+      EXPECT_MESSAGE "expected path:\n  non_readable_file\nto be readable")
 
     assert_fatal_error(
       CALL assert NOT IS_READABLE some_file
-      MESSAGE "expected path:\n  some_file\nnot to be readable")
+      EXPECT_MESSAGE "expected path:\n  some_file\nnot to be readable")
   endsection()
 endsection()
 
@@ -244,11 +248,11 @@ section("path writability condition assertions")
   section("it should fail to assert path writability conditions")
     assert_fatal_error(
       CALL assert IS_WRITABLE non_writable_file
-      MESSAGE "expected path:\n  non_writable_file\nto be writable")
+      EXPECT_MESSAGE "expected path:\n  non_writable_file\nto be writable")
 
     assert_fatal_error(
       CALL assert NOT IS_WRITABLE some_file
-      MESSAGE "expected path:\n  some_file\nnot to be writable")
+      EXPECT_MESSAGE "expected path:\n  some_file\nnot to be writable")
   endsection()
 endsection()
 
@@ -270,11 +274,12 @@ section("executable path condition assertions")
   section("it should fail to assert executable path conditions")
     assert_fatal_error(
       CALL assert IS_EXECUTABLE some_file
-      MESSAGE "expected path:\n  some_file\nto be an executable")
+      EXPECT_MESSAGE "expected path:\n  some_file\nto be an executable")
 
     assert_fatal_error(
       CALL assert NOT IS_EXECUTABLE some_executable
-      MESSAGE "expected path:\n  some_executable\nnot to be an executable")
+      EXPECT_MESSAGE "expected path:\n  some_executable\n"
+        "not to be an executable")
   endsection()
 endsection()
 
@@ -294,11 +299,13 @@ section("file recency condition assertions")
   section("it should fail to assert file recency conditions")
     assert_fatal_error(
       CALL assert old_file IS_NEWER_THAN new_file
-      MESSAGE "expected file:\n  old_file\nto be newer than:\n  new_file")
+      EXPECT_MESSAGE "expected file:\n  old_file\n"
+        "to be newer than:\n  new_file")
 
     assert_fatal_error(
       CALL assert NOT new_file IS_NEWER_THAN old_file
-      MESSAGE "expected file:\n  new_file\nnot to be newer than:\n  old_file")
+      EXPECT_MESSAGE "expected file:\n  new_file\n"
+        "not to be newer than:\n  old_file")
   endsection()
 endsection()
 
@@ -314,11 +321,11 @@ section("directory path condition assertions")
   section("it should fail to assert directory path conditions")
     assert_fatal_error(
       CALL assert IS_DIRECTORY some_file
-      MESSAGE "expected path:\n  some_file\nto be a directory")
+      EXPECT_MESSAGE "expected path:\n  some_file\nto be a directory")
 
     assert_fatal_error(
       CALL assert NOT IS_DIRECTORY some_directory
-      MESSAGE "expected path:\n  some_directory\nnot to be a directory")
+      EXPECT_MESSAGE "expected path:\n  some_directory\nnot to be a directory")
   endsection()
 endsection()
 
@@ -334,11 +341,12 @@ section("symbolic link path condition assertions")
   section("it should fail to assert symbolic link path conditions")
     assert_fatal_error(
       CALL assert IS_SYMLINK some_file
-      MESSAGE "expected path:\n  some_file\nto be a symbolic link")
+      EXPECT_MESSAGE "expected path:\n  some_file\nto be a symbolic link")
 
     assert_fatal_error(
       CALL assert NOT IS_SYMLINK some_symlink
-      MESSAGE "expected path:\n  some_symlink\nnot to be a symbolic link")
+      EXPECT_MESSAGE "expected path:\n  some_symlink\n"
+        "not to be a symbolic link")
   endsection()
 endsection()
 
@@ -351,11 +359,12 @@ section("absolute path condition assertions")
   section("it should fail to assert absolute path conditions")
     assert_fatal_error(
       CALL assert IS_ABSOLUTE some/relative/path
-      MESSAGE "expected path:\n  some/relative/path\nto be absolute")
+      EXPECT_MESSAGE "expected path:\n  some/relative/path\nto be absolute")
 
     assert_fatal_error(
       CALL assert NOT IS_ABSOLUTE /some/absolute/path
-      MESSAGE "expected path:\n  /some/absolute/path\nnot to be absolute")
+      EXPECT_MESSAGE "expected path:\n  /some/absolute/path\n"
+        "not to be absolute")
   endsection()
 endsection()
 
@@ -373,11 +382,13 @@ section("regular expression match condition assertions")
   section("it should fail to assert regular expression match conditions")
     assert_fatal_error(
       CALL assert "some string" MATCHES "so.*other.*ing"
-      MESSAGE "expected string:\n  some string\nto match:\n  so.*other.*ing")
+      EXPECT_MESSAGE "expected string:\n  some string\n"
+        "to match:\n  so.*other.*ing")
 
     assert_fatal_error(
       CALL assert NOT "some string" MATCHES "so.*ing"
-      MESSAGE "expected string:\n  some string\nnot to match:\n  so.*ing")
+      EXPECT_MESSAGE "expected string:\n  some string\n"
+        "not to match:\n  so.*ing")
   endsection()
 endsection()
 
@@ -403,23 +414,24 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 7 LESS 7
-        MESSAGE "expected number:\n  7\nto be less than:\n  7")
+        EXPECT_MESSAGE "expected number:\n  7\nto be less than:\n  7")
 
       assert_fatal_error(
         CALL assert 7 GREATER 7
-        MESSAGE "expected number:\n  7\nto be greater than:\n  7")
+        EXPECT_MESSAGE "expected number:\n  7\nto be greater than:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 EQUAL 7
-        MESSAGE "expected number:\n  7\nnot to be equal to:\n  7")
+        EXPECT_MESSAGE "expected number:\n  7\nnot to be equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 LESS_EQUAL 7
-        MESSAGE "expected number:\n  7\nnot to be less than or equal to:\n  7")
+        EXPECT_MESSAGE "expected number:\n  7\n"
+          "not to be less than or equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 GREATER_EQUAL 7
-        MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE "expected number:\n  7\n"
           "not to be greater than or equal to:\n  7")
     endsection()
   endsection()
@@ -442,23 +454,25 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert NOT 7 LESS 13
-        MESSAGE "expected number:\n  7\nnot to be less than:\n  13")
+        EXPECT_MESSAGE "expected number:\n  7\nnot to be less than:\n  13")
 
       assert_fatal_error(
         CALL assert 7 GREATER 13
-        MESSAGE "expected number:\n  7\nto be greater than:\n  13")
+        EXPECT_MESSAGE "expected number:\n  7\nto be greater than:\n  13")
 
       assert_fatal_error(
         CALL assert 7 EQUAL 13
-        MESSAGE "expected number:\n  7\nto be equal to:\n  13")
+        EXPECT_MESSAGE "expected number:\n  7\nto be equal to:\n  13")
 
       assert_fatal_error(
         CALL assert NOT 7 LESS_EQUAL 13
-        MESSAGE "expected number:\n  7\nnot to be less than or equal to:\n  13")
+        EXPECT_MESSAGE "expected number:\n  7\n"
+          "not to be less than or equal to:\n  13")
 
       assert_fatal_error(
         CALL assert 7 GREATER_EQUAL 13
-        MESSAGE "expected number:\n  7\nto be greater than or equal to:\n  13")
+        EXPECT_MESSAGE "expected number:\n  7\n"
+          "to be greater than or equal to:\n  13")
     endsection()
   endsection()
 
@@ -480,23 +494,24 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 13 LESS 7
-        MESSAGE "expected number:\n  13\nto be less than:\n  7")
+        EXPECT_MESSAGE "expected number:\n  13\nto be less than:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 13 GREATER 7
-        MESSAGE "expected number:\n  13\nnot to be greater than:\n  7")
+        EXPECT_MESSAGE "expected number:\n  13\nnot to be greater than:\n  7")
 
       assert_fatal_error(
         CALL assert 13 EQUAL 7
-        MESSAGE "expected number:\n  13\nto be equal to:\n  7")
+        EXPECT_MESSAGE "expected number:\n  13\nto be equal to:\n  7")
 
       assert_fatal_error(
         CALL assert 13 LESS_EQUAL 7
-        MESSAGE "expected number:\n  13\nto be less than or equal to:\n  7")
+        EXPECT_MESSAGE "expected number:\n  13\n"
+          "to be less than or equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 13 GREATER_EQUAL 7
-        MESSAGE "expected number:\n  13\n"
+        EXPECT_MESSAGE "expected number:\n  13\n"
           "not to be greater than or equal to:\n  7")
     endsection()
   endsection()
@@ -521,24 +536,25 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 7 LESS  "some string"
-        MESSAGE "expected number:\n  7\nto be less than:\n  some string")
+        EXPECT_MESSAGE "expected number:\n  7\nto be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 GREATER "some string"
-        MESSAGE "expected number:\n  7\nto be greater than:\n  some string")
+        EXPECT_MESSAGE "expected number:\n  7\n"
+          "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 EQUAL "some string"
-        MESSAGE "expected number:\n  7\nto be equal to:\n  some string")
+        EXPECT_MESSAGE "expected number:\n  7\nto be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 LESS_EQUAL "some string"
-        MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE "expected number:\n  7\n"
           "to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 GREATER_EQUAL "some string"
-        MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE "expected number:\n  7\n"
           "to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -566,27 +582,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert "some string" STRLESS "some string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "to be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some string" STRGREATER "some string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STREQUAL "some string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "not to be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRLESS_EQUAL "some string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "not to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER_EQUAL "some string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "not to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -609,27 +625,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert NOT "some other string" STRLESS "some string"
-        MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE "expected string:\n  some other string\n"
           "not to be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STRGREATER "some string"
-        MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE "expected string:\n  some other string\n"
           "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STREQUAL "some string"
-        MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE "expected string:\n  some other string\n"
           "to be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some other string" STRLESS_EQUAL "some string"
-        MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE "expected string:\n  some other string\n"
           "not to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STRGREATER_EQUAL "some string"
-        MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE "expected string:\n  some other string\n"
           "to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -652,27 +668,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert "some string" STRLESS "some other string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "to be less than:\n  some other string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER "some other string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "not to be greater than:\n  some other string")
 
       assert_fatal_error(
         CALL assert "some string" STREQUAL "some other string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "to be equal to:\n  some other string")
 
       assert_fatal_error(
         CALL assert "some string" STRLESS_EQUAL "some other string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "to be less than or equal to:\n  some other string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER_EQUAL "some other string"
-        MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE "expected string:\n  some string\n"
           "not to be greater than or equal to:\n  some other string")
     endsection()
   endsection()
@@ -701,24 +717,26 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_LESS 1.02.3
-        MESSAGE "expected version:\n  1.2.3\nto be less than:\n  1.02.3")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\nto be less than:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER 1.02.3
-        MESSAGE "expected version:\n  1.2.3\nto be greater than:\n  1.02.3")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+          "to be greater than:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_EQUAL 1.02.3
-        MESSAGE "expected version:\n  1.2.3\nnot to be equal to:\n  1.02.3")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+          "not to be equal to:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS_EQUAL 1.02.3
-        MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
           "not to be less than or equal to:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_GREATER_EQUAL 1.02.3
-        MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
           "not to be greater than or equal to:\n  1.02.3")
     endsection()
   endsection()
@@ -741,24 +759,26 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS 1.3.4
-        MESSAGE "expected version:\n  1.2.3\nnot to be less than:\n  1.3.4")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+          "not to be less than:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER 1.3.4
-        MESSAGE "expected version:\n  1.2.3\nto be greater than:\n  1.3.4")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+          "to be greater than:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_EQUAL 1.3.4
-        MESSAGE "expected version:\n  1.2.3\nto be equal to:\n  1.3.4")
+        EXPECT_MESSAGE "expected version:\n  1.2.3\nto be equal to:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS_EQUAL 1.3.4
-        MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
           "not to be less than or equal to:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER_EQUAL 1.3.4
-        MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
           "to be greater than or equal to:\n  1.3.4")
     endsection()
   endsection()
@@ -781,24 +801,25 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_LESS 1.2.3
-        MESSAGE "expected version:\n  1.3.4\nto be less than:\n  1.2.3")
+        EXPECT_MESSAGE "expected version:\n  1.3.4\nto be less than:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert NOT 1.3.4 VERSION_GREATER 1.2.3
-        MESSAGE "expected version:\n  1.3.4\nnot to be greater than:\n  1.2.3")
+        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
+          "not to be greater than:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_EQUAL 1.2.3
-        MESSAGE "expected version:\n  1.3.4\nto be equal to:\n  1.2.3")
+        EXPECT_MESSAGE "expected version:\n  1.3.4\nto be equal to:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_LESS_EQUAL 1.2.3
-        MESSAGE "expected version:\n  1.3.4\n"
+        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
           "to be less than or equal to:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert NOT 1.3.4 VERSION_GREATER_EQUAL 1.2.3
-        MESSAGE "expected version:\n  1.3.4\n"
+        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
           "not to be greater than or equal to:\n  1.2.3")
     endsection()
   endsection()
@@ -820,12 +841,12 @@ section("path equality condition assertions")
   section("it should fail to assert path equality conditions")
     assert_fatal_error(
       CALL assert "/some/path" PATH_EQUAL "/some/other/path"
-      MESSAGE "expected path:\n  /some/path\n"
+      EXPECT_MESSAGE "expected path:\n  /some/path\n"
         "to be equal to:\n  /some/other/path")
 
     assert_fatal_error(
       CALL assert NOT "/some/path" PATH_EQUAL "/some//path"
-      MESSAGE "expected path:\n  /some/path\n"
+      EXPECT_MESSAGE "expected path:\n  /some/path\n"
         "not to be equal to:\n  /some//path")
   endsection()
 endsection()

--- a/test/assert_execute_process.cmake
+++ b/test/assert_execute_process.cmake
@@ -9,7 +9,7 @@ section("process execution assertions")
 
   section("it should fail to assert a process execution")
     assert_fatal_error(
-      CALL assert_execute_process "${CMAKE_COMMAND}" -E true ERROR .*
+      CALL assert_execute_process "${CMAKE_COMMAND}" -E true EXPECT_ERROR .*
       EXPECT_MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
   endsection()
 endsection()
@@ -19,7 +19,7 @@ section("failed process execution assertions")
 
   section("it should assert a failed process execution")
     assert_execute_process(
-      "${CMAKE_COMMAND}" -E make_directory some-file ERROR .*)
+      "${CMAKE_COMMAND}" -E make_directory some-file EXPECT_ERROR .*)
   endsection()
 
   section("it should fail to assert a failed process execution")
@@ -59,14 +59,14 @@ section("process execution error assertions")
   section("it should assert a process execution error")
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-      ERROR "Error creating directory" ".*some-file")
+      EXPECT_ERROR "Error creating directory" ".*some-file")
   endsection()
 
   section("it should fail to assert a process execution error")
     assert_fatal_error(
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-        ERROR "Error creating directory" ".*some-other-file"
+        EXPECT_ERROR "Error creating directory" ".*some-other-file"
       EXPECT_MESSAGE "expected the error:\n"
         ".*\n"
         "of command:\n"

--- a/test/assert_execute_process.cmake
+++ b/test/assert_execute_process.cmake
@@ -36,14 +36,14 @@ section("process execution output assertions")
   section("it should assert a process execution output")
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-      OUTPUT "Hello" ".*!")
+      EXPECT_OUTPUT "Hello" ".*!")
   endsection()
 
   section("it should fail to assert a process execution output")
     assert_fatal_error(
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
-        OUTPUT "Hello" ".*earth!"
+        EXPECT_OUTPUT "Hello" ".*earth!"
       EXPECT_MESSAGE "expected the output:\n"
         ".*\n"
         "of command:\n"

--- a/test/assert_execute_process.cmake
+++ b/test/assert_execute_process.cmake
@@ -10,7 +10,7 @@ section("process execution assertions")
   section("it should fail to assert a process execution")
     assert_fatal_error(
       CALL assert_execute_process "${CMAKE_COMMAND}" -E true ERROR .*
-      MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
+      EXPECT_MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
   endsection()
 endsection()
 
@@ -25,7 +25,7 @@ section("failed process execution assertions")
   section("it should fail to assert a failed process execution")
     assert_fatal_error(
       CALL assert_execute_process "${CMAKE_COMMAND}" -E make_directory some-file
-      MESSAGE "expected command:\n"
+      EXPECT_MESSAGE "expected command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"
         "not to fail with error:\n"
         "  Error creating directory \"some-file\".")
@@ -44,7 +44,7 @@ section("process execution output assertions")
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
         OUTPUT "Hello" ".*earth!"
-      MESSAGE "expected the output:\n"
+      EXPECT_MESSAGE "expected the output:\n"
         ".*\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E echo Hello world!\n"
@@ -67,7 +67,7 @@ section("process execution error assertions")
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
         ERROR "Error creating directory" ".*some-other-file"
-      MESSAGE "expected the error:\n"
+      EXPECT_MESSAGE "expected the error:\n"
         ".*\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"

--- a/test/assert_fatal_error.cmake
+++ b/test/assert_fatal_error.cmake
@@ -5,24 +5,24 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 section("it should assert a fatal error message")
   assert_fatal_error(
     CALL message FATAL_ERROR "some fatal error message"
-    MESSAGE "some fa.*ror message")
+    EXPECT_MESSAGE "some fa.*ror message")
 
   assert_fatal_error(
     CALL message FATAL_ERROR "some fatal error message "
       "with additional message"
-    MESSAGE "some fa.*ror message with additional message")
+    EXPECT_MESSAGE "some fa.*ror message with additional message")
 endsection()
 
 section("it should fail to assert a fatal error message")
   macro(failed_assertion)
     assert_fatal_error(
       CALL message FATAL_ERROR "some fatal error message"
-      MESSAGE "some other fa.*ror message")
+      EXPECT_MESSAGE "some other fa.*ror message")
   endmacro()
 
   assert_fatal_error(
     CALL failed_assertion
-    MESSAGE "expected fatal error message:\n"
+    EXPECT_MESSAGE "expected fatal error message:\n"
       "  some fatal error message\n"
       "to match:\n"
       "  some other fa.*ror message")
@@ -32,11 +32,12 @@ section("it should fail to assert a fatal error message "
   "because there is nothing to assert")
 
   macro(failed_assertion)
-    assert_fatal_error(CALL message "some message" MESSAGE "some message")
+    assert_fatal_error(
+      CALL message "some message" EXPECT_MESSAGE "some message")
   endmacro()
 
   assert_fatal_error(
     CALL failed_assertion
-    MESSAGE "expected to receive a fatal error message that matches:\n"
+    EXPECT_MESSAGE "expected to receive a fatal error message that matches:\n"
       "  some message")
 endsection()

--- a/test/fail.cmake
+++ b/test/fail.cmake
@@ -6,15 +6,15 @@ section("given strings")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail "single line string"
-      MESSAGE "single line string")
+      EXPECT_MESSAGE "single line string")
 
     assert_fatal_error(
       CALL fail "multiple\nlines\nstring"
-      MESSAGE "multiple\nlines\nstring")
+      EXPECT_MESSAGE "multiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" "multiple\nlines\nstring"
-      MESSAGE "single line string\nmultiple\nlines\nstring")
+      EXPECT_MESSAGE "single line string\nmultiple\nlines\nstring")
   endsection()
 endsection()
 
@@ -26,23 +26,23 @@ section("given variables")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail SINGLE
-      MESSAGE "single line variable")
+      EXPECT_MESSAGE "single line variable")
 
     assert_fatal_error(
       CALL fail MULTIPLE
-      MESSAGE "multiple\nlines\nvariable")
+      EXPECT_MESSAGE "multiple\nlines\nvariable")
 
     assert_fatal_error(
       CALL fail CONTAINS_SINGLE
-      MESSAGE "single line variable\nof variable:\n  SINGLE")
+      EXPECT_MESSAGE "single line variable\nof variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE
-      MESSAGE "single line variable\nmultiple\nlines\nvariable")
+      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
-      MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
         "single line variable\nof variable:\n  SINGLE")
   endsection()
 endsection()
@@ -51,52 +51,53 @@ section("given strings and variables")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail "single line string" SINGLE
-      MESSAGE "single line string:\n  single line variable")
+      EXPECT_MESSAGE "single line string:\n  single line variable")
 
     assert_fatal_error(
       CALL fail SINGLE "single line string"
-      MESSAGE "single line variable\nsingle line string")
+      EXPECT_MESSAGE "single line variable\nsingle line string")
 
     assert_fatal_error(
       CALL fail "multiple\nlines\nstring" MULTIPLE
-      MESSAGE "multiple\nlines\nstring:\n  multiple\n  lines\n  variable")
+      EXPECT_MESSAGE "multiple\nlines\nstring:\n"
+        "  multiple\n  lines\n  variable")
 
     assert_fatal_error(
       CALL fail MULTIPLE "multiple\nlines\nstring"
-      MESSAGE "multiple\nlines\nvariable\nmultiple\nlines\nstring")
+      EXPECT_MESSAGE "multiple\nlines\nvariable\nmultiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" CONTAINS_SINGLE
-      MESSAGE "single line string:\n  single line variable\n"
+      EXPECT_MESSAGE "single line string:\n  single line variable\n"
         "of variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail CONTAINS_SINGLE "single line string"
-      MESSAGE "single line variable\nof variable:\n  SINGLE\n"
+      EXPECT_MESSAGE "single line variable\nof variable:\n  SINGLE\n"
         "single line string")
 
     assert_fatal_error(
       CALL fail "single line string" "multiple\nlines\nstring"
         SINGLE MULTIPLE CONTAINS_SINGLE
-      MESSAGE "single line string\nmultiple\nlines\nstring:\n"
+      EXPECT_MESSAGE "single line string\nmultiple\nlines\nstring:\n"
         "  single line variable\n  multiple\n  lines\n  variable\n"
         "  single line variable\nof variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
         "single line string" "multiple\nlines\nstring"
-      MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
         "single line variable\nof variable:\n  SINGLE\n"
         "single line string\nmultiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" SINGLE "multiple\nlines\nstring" MULTIPLE
-      MESSAGE "single line string:\n  single line variable\n"
+      EXPECT_MESSAGE "single line string:\n  single line variable\n"
         "multiple\nlines\nstring:\n  multiple\n  lines\n  variable")
 
     assert_fatal_error(
       CALL fail SINGLE "single line string" MULTIPLE "multiple\nlines\nstring"
-      MESSAGE "single line variable\nsingle line string:\n"
+      EXPECT_MESSAGE "single line variable\nsingle line string:\n"
         "  multiple\n  lines\n  variable\nmultiple\nlines\nstring")
   endsection()
 endsection()


### PR DESCRIPTION
This pull request resolves #259 by renaming the following options:
- The `MESSAGE` option in the `assert_fatal_error` function has been renamed to `EXPECT_MESSAGE`.
- The `OUTPUT` and `ERROR` options in the `assert_execute_process` function have been renamed to `EXPECT_OUTPUT` and `EXPECT_ERROR`, respectively.