### PR TITLE
Add `EXPECT_FAIL` Option to Assert Execute Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,12 @@ Asserts whether the given command correctly executes a process.
 ```cmake
 assert_execute_process(
   [COMMAND] <command> [<arguments>...]
+  [EXPECT_FAIL]
   [EXPECT_OUTPUT <output>...]
   [EXPECT_ERROR <error>...])
 ```
 
-This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `EXPECT_ERROR` is specified, it instead asserts whether it fails to execute the process.
+This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `EXPECT_FAIL` or `EXPECT_ERROR` is specified, it instead asserts whether it fails to execute the process.
 
 If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the executed process matches the expected `<output>`. If more than one `<output>` string is given, they are concatenated into a single output with no separator between the strings.
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -429,12 +429,13 @@ endfunction()
 #
 # assert_execute_process(
 #   [COMMAND] <command> [<arguments>...]
+#   [EXPECT_FAIL]
 #   [EXPECT_OUTPUT <output>...]
 #   [EXPECT_ERROR <error>...])
 #
 # This function asserts whether the given `<command>` and `<arguments>`
-# successfully execute a process. If `EXPECT_ERROR` is specified, it instead
-# asserts whether it fails to execute the process.
+# successfully execute a process. If `EXPECT_FAIL` or `EXPECT_ERROR` is
+# specified, it instead asserts whether it fails to execute the process.
 #
 # If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the
 # executed process matches the expected `<output>`. If more than one `<output>`
@@ -447,7 +448,7 @@ endfunction()
 # between the strings.
 function(assert_execute_process)
   cmake_parse_arguments(
-    PARSE_ARGV 0 ARG "" "" "COMMAND;EXPECT_OUTPUT;EXPECT_ERROR")
+    PARSE_ARGV 0 ARG EXPECT_FAIL "" "COMMAND;EXPECT_OUTPUT;EXPECT_ERROR")
 
   if(NOT DEFINED ARG_COMMAND)
     set(ARG_COMMAND ${ARG_UNPARSED_ARGUMENTS})
@@ -459,7 +460,7 @@ function(assert_execute_process)
     OUTPUT_VARIABLE OUT
     ERROR_VARIABLE ERR)
 
-  if(DEFINED ARG_EXPECT_ERROR)
+  if(ARG_EXPECT_FAIL OR DEFINED ARG_EXPECT_ERROR)
     if(RES EQUAL 0)
       string(REPLACE ";" " " COMMAND "${ARG_COMMAND}")
       fail("expected command" COMMAND "to fail")

--- a/test/assert_execute_process.cmake
+++ b/test/assert_execute_process.cmake
@@ -9,7 +9,7 @@ section("process execution assertions")
 
   section("it should fail to assert a process execution")
     assert_fatal_error(
-      CALL assert_execute_process "${CMAKE_COMMAND}" -E true EXPECT_ERROR .*
+      CALL assert_execute_process "${CMAKE_COMMAND}" -E true EXPECT_FAIL
       EXPECT_MESSAGE "expected command:\n  ${CMAKE_COMMAND} -E true\nto fail")
   endsection()
 endsection()
@@ -19,7 +19,7 @@ section("failed process execution assertions")
 
   section("it should assert a failed process execution")
     assert_execute_process(
-      "${CMAKE_COMMAND}" -E make_directory some-file EXPECT_ERROR .*)
+      "${CMAKE_COMMAND}" -E make_directory some-file EXPECT_FAIL)
   endsection()
 
   section("it should fail to assert a failed process execution")


### PR DESCRIPTION
This pull request resolves #261 by adding a new `EXPECT_FAIL` option to the `assert_execute_process` function, allowing the result of an executed process to be asserted without requiring the assertion of the error message.