### PR TITLE
Add Option to Specify Operator in Assert Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,15 +211,17 @@ Asserts whether the given command correctly executes a process.
 assert_execute_process(
   [COMMAND] <command> [<arguments>...]
   [EXPECT_FAIL]
-  [EXPECT_OUTPUT <output>...]
-  [EXPECT_ERROR <error>...])
+  [EXPECT_OUTPUT [MATCHES|STREQUAL] <output>...]
+  [EXPECT_ERROR [MATCHES|STREQUAL] <error>...])
 ```
 
-This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `EXPECT_FAIL` or `EXPECT_ERROR` is specified, it instead asserts whether it fails to execute the process.
+This function asserts whether the given `<command>` and `<arguments>` successfully execute a process. If `EXPECT_FAIL` or `EXPECT_ERROR` is specified, it asserts that the process fails to execute.
 
-If `EXPECT_OUTPUT` is specified, it also asserts whether the output of the executed process matches the expected `<output>`. If more than one `<output>` string is given, they are concatenated into a single output with no separator between the strings.
+If `EXPECT_OUTPUT` or `EXPECT_ERROR` is specified, it also asserts whether the output or error of the executed process matches the expected output or error.
 
-If `EXPECT_ERROR` is specified, it also asserts whether the error of the executed process matches the expected `<error>`. If more than one `<error>` string is given, they are concatenated into a single error with no separator between the strings.
+If `MATCHES` is specified, it asserts whether the output or error matches the `<output>` or `<error>`. If `STREQUAL` is specified, it asserts whether the output or error is equal to `<output>` or `<error>`. If neither is specified, it defaults to `MATCHES`.
+
+If more than one `<output>` or `<error>` string is given, they are concatenated into a single output or error with no separator between the strings.
 
 #### Example
 
@@ -229,7 +231,7 @@ assert_execute_process(
   EXPECT_OUTPUT hello)
 ```
 
-The above example asserts whether the call to `${CMAKE_COMMAND} -E echo hello` successfully executes a process whose output matches `hello`. If it somehow fails to execute the process, it will throw the following fatal error message:
+The above example asserts that the call to `${CMAKE_COMMAND} -E echo hello` successfully executes a process whose output is equal to `hello`. If the process fails to execute, it will throw the following fatal error message:
 
 ```
 expected command:

--- a/README.md
+++ b/README.md
@@ -175,12 +175,15 @@ Asserts whether a command call throws a fatal error message.
 
 ```cmake
 assert_fatal_error(
-  CALL <command> [<arguments>...] EXPECT_MESSAGE <message>...)
+  CALL <command> [<arguments>...]
+  EXPECT_MESSAGE [MATCHES|STREQUAL] <message>...)
 ```
 
-This function asserts whether a function or macro named `<command>`, called with the specified `<arguments>`, throws a fatal error message that matches the expected `<message>`.
+This function asserts whether a function or macro named `<command>`, called with the specified `<arguments>`, throws a fatal error message that satisfies the expected message.
 
-If more than one `<message>` string is given, they are concatenated into a single message with no separator between the strings.
+If `MATCHES` is specified, it asserts whether the received message matches the `<message>`. If `STREQUAL` is specified, it asserts whether the received message is equal to `<message>`. If nothing is specified, it defaults to the `MATCHES` parameter.
+
+If more than one `<message>` string is given, they are concatenated into a single message with no separators.
 
 #### Example
 
@@ -191,14 +194,13 @@ endfunction()
 
 assert_fatal_error(
   CALL throw_fatal_error "some message"
-  EXPECT_MESSAGE "some message")
+  EXPECT_MESSAGE STREQUAL "some message")
 ```
 
-The above example asserts whether the call to `throw_fatal_error("some message")` throws a fatal error message that matches `some message`. If it somehow does not capture any fatal error message, it will throw the following fatal error message:
+The above example asserts whether the call to `throw_fatal_error("some message")` throws a fatal error message equal to `some message`. If it somehow does not capture any fatal error message, it will throw the following fatal error message:
 
 ```
-expected to receive a fatal error message that matches:
-  some message
+expected to receive a fatal error message
 ```
 
 ### `assert_execute_process`

--- a/test/assert.cmake
+++ b/test/assert.cmake
@@ -43,11 +43,11 @@ section("boolean condition assertions")
   section("it should fail to assert boolean conditions")
     assert_fatal_error(
       CALL assert FALSE
-      EXPECT_MESSAGE "expected:\n  FALSE\nto resolve to true")
+      EXPECT_MESSAGE STREQUAL "expected:\n  FALSE\nto resolve to true")
 
     assert_fatal_error(
       CALL assert NOT TRUE
-      EXPECT_MESSAGE "expected:\n  NOT TRUE\nto resolve to true")
+      EXPECT_MESSAGE STREQUAL "expected:\n  NOT TRUE\nto resolve to true")
   endsection()
 endsection()
 
@@ -63,11 +63,13 @@ section("command existence condition assertions")
   section("it should fail to assert command existence conditions")
     assert_fatal_error(
       CALL assert COMMAND non_existing_command
-      EXPECT_MESSAGE "expected command:\n  non_existing_command\nto be defined")
+      EXPECT_MESSAGE STREQUAL
+        "expected command:\n  non_existing_command\nto be defined")
 
     assert_fatal_error(
       CALL assert NOT COMMAND existing_command
-      EXPECT_MESSAGE "expected command:\n  existing_command\nnot to be defined")
+      EXPECT_MESSAGE STREQUAL
+        "expected command:\n  existing_command\nnot to be defined")
   endsection()
 endsection()
 
@@ -80,11 +82,11 @@ section("policy existence condition assertions")
   section("it should fail to assert policy existence conditions")
     assert_fatal_error(
       CALL assert POLICY CMPXXXX
-      EXPECT_MESSAGE "expected policy:\n  CMPXXXX\nto exist")
+      EXPECT_MESSAGE STREQUAL "expected policy:\n  CMPXXXX\nto exist")
 
     assert_fatal_error(
       CALL assert NOT POLICY CMP0000
-      EXPECT_MESSAGE "expected policy:\n  CMP0000\nnot to exist")
+      EXPECT_MESSAGE STREQUAL "expected policy:\n  CMP0000\nnot to exist")
   endsection()
 endsection()
 
@@ -105,13 +107,13 @@ section("target existence condition assertions")
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert TARGET non_existing_target\n"
-      "  EXPECT_MESSAGE \"expected target:\\n  non_existing_target\\n\"\n"
-      "    \"to exist\")\n"
+      "  EXPECT_MESSAGE STREQUAL\n"
+      "    \"expected target:\\n  non_existing_target\\nto exist\")\n"
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert NOT TARGET some_target\n"
-      "  EXPECT_MESSAGE \"expected target:\\n  some_target\\n\"\n"
-      "    \"not to exist\")\n")
+      "  EXPECT_MESSAGE STREQUAL\n"
+      "    \"expected target:\\n  some_target\\nnot to exist\")\n")
   endsection()
 endsection()
 
@@ -132,11 +134,13 @@ section("test existence condition assertions")
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert TEST non_existing_test\n"
-      "  EXPECT_MESSAGE \"expected test:\\n  non_existing_test\\nto exist\")\n"
+      "  EXPECT_MESSAGE STREQUAL\n"
+      "    \"expected test:\\n  non_existing_test\\nto exist\")\n"
       "\n"
       "assert_fatal_error(\n"
       "  CALL assert NOT TEST some_test\n"
-      "  EXPECT_MESSAGE \"expected test:\\n  some_test\\nnot to exist\")\n")
+      "  EXPECT_MESSAGE STREQUAL\n"
+      "    \"expected test:\\n  some_test\\nnot to exist\")\n")
   endsection()
 endsection()
 
@@ -152,13 +156,13 @@ section("variable existence condition assertions")
   section("it should fail to assert variable existence conditions")
     assert_fatal_error(
       CALL assert DEFINED NON_EXISTING_VARIABLE
-      EXPECT_MESSAGE "expected variable:\n  NON_EXISTING_VARIABLE\n"
-        "to be defined")
+      EXPECT_MESSAGE STREQUAL
+        "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined")
 
     assert_fatal_error(
       CALL assert NOT DEFINED EXISTING_VARIABLE
-      EXPECT_MESSAGE "expected variable:\n  EXISTING_VARIABLE\n"
-        "not to be defined")
+      EXPECT_MESSAGE STREQUAL
+        "expected variable:\n  EXISTING_VARIABLE\nnot to be defined")
   endsection()
 endsection()
 
@@ -179,14 +183,14 @@ section("list element existence condition assertions")
   section("it should fail to assert list element existence conditions")
     assert_fatal_error(
       CALL assert "other element" IN_LIST SOME_LIST
-      EXPECT_MESSAGE "expected string:\n  other element\n"
-        "to exist in:\n  some element;some other element\n"
+      EXPECT_MESSAGE STREQUAL "expected string:\n  other element\n"
+        "to exist in:\n  some element\;some other element\n"
         "of variable:\n  SOME_LIST")
 
     assert_fatal_error(
       CALL assert NOT "some element" IN_LIST SOME_LIST
-      EXPECT_MESSAGE "expected string:\n  some element\n"
-        "not to exist in:\n  some element;some other element\n"
+      EXPECT_MESSAGE STREQUAL "expected string:\n  some element\n"
+        "not to exist in:\n  some element\;some other element\n"
         "of variable:\n  SOME_LIST")
   endsection()
 endsection()
@@ -203,11 +207,11 @@ section("path existence condition assertions")
   section("it should fail to assert path existence conditions")
     assert_fatal_error(
       CALL assert EXISTS non_existing_file
-      EXPECT_MESSAGE "expected path:\n  non_existing_file\nto exist")
+      EXPECT_MESSAGE STREQUAL "expected path:\n  non_existing_file\nto exist")
 
     assert_fatal_error(
       CALL assert NOT EXISTS some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nnot to exist")
+      EXPECT_MESSAGE STREQUAL "expected path:\n  some_file\nnot to exist")
   endsection()
 endsection()
 
@@ -226,11 +230,12 @@ section("path readability condition assertions")
   section("it should fail to assert path readability conditions")
     assert_fatal_error(
       CALL assert IS_READABLE non_readable_file
-      EXPECT_MESSAGE "expected path:\n  non_readable_file\nto be readable")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  non_readable_file\nto be readable")
 
     assert_fatal_error(
       CALL assert NOT IS_READABLE some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nnot to be readable")
+      EXPECT_MESSAGE STREQUAL "expected path:\n  some_file\nnot to be readable")
   endsection()
 endsection()
 
@@ -248,11 +253,12 @@ section("path writability condition assertions")
   section("it should fail to assert path writability conditions")
     assert_fatal_error(
       CALL assert IS_WRITABLE non_writable_file
-      EXPECT_MESSAGE "expected path:\n  non_writable_file\nto be writable")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  non_writable_file\nto be writable")
 
     assert_fatal_error(
       CALL assert NOT IS_WRITABLE some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nnot to be writable")
+      EXPECT_MESSAGE STREQUAL "expected path:\n  some_file\nnot to be writable")
   endsection()
 endsection()
 
@@ -274,12 +280,13 @@ section("executable path condition assertions")
   section("it should fail to assert executable path conditions")
     assert_fatal_error(
       CALL assert IS_EXECUTABLE some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nto be an executable")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_file\nto be an executable")
 
     assert_fatal_error(
       CALL assert NOT IS_EXECUTABLE some_executable
-      EXPECT_MESSAGE "expected path:\n  some_executable\n"
-        "not to be an executable")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_executable\nnot to be an executable")
   endsection()
 endsection()
 
@@ -299,12 +306,12 @@ section("file recency condition assertions")
   section("it should fail to assert file recency conditions")
     assert_fatal_error(
       CALL assert old_file IS_NEWER_THAN new_file
-      EXPECT_MESSAGE "expected file:\n  old_file\n"
+      EXPECT_MESSAGE STREQUAL "expected file:\n  old_file\n"
         "to be newer than:\n  new_file")
 
     assert_fatal_error(
       CALL assert NOT new_file IS_NEWER_THAN old_file
-      EXPECT_MESSAGE "expected file:\n  new_file\n"
+      EXPECT_MESSAGE STREQUAL "expected file:\n  new_file\n"
         "not to be newer than:\n  old_file")
   endsection()
 endsection()
@@ -321,11 +328,13 @@ section("directory path condition assertions")
   section("it should fail to assert directory path conditions")
     assert_fatal_error(
       CALL assert IS_DIRECTORY some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nto be a directory")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_file\nto be a directory")
 
     assert_fatal_error(
       CALL assert NOT IS_DIRECTORY some_directory
-      EXPECT_MESSAGE "expected path:\n  some_directory\nnot to be a directory")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_directory\nnot to be a directory")
   endsection()
 endsection()
 
@@ -341,12 +350,13 @@ section("symbolic link path condition assertions")
   section("it should fail to assert symbolic link path conditions")
     assert_fatal_error(
       CALL assert IS_SYMLINK some_file
-      EXPECT_MESSAGE "expected path:\n  some_file\nto be a symbolic link")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_file\nto be a symbolic link")
 
     assert_fatal_error(
       CALL assert NOT IS_SYMLINK some_symlink
-      EXPECT_MESSAGE "expected path:\n  some_symlink\n"
-        "not to be a symbolic link")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some_symlink\nnot to be a symbolic link")
   endsection()
 endsection()
 
@@ -359,12 +369,13 @@ section("absolute path condition assertions")
   section("it should fail to assert absolute path conditions")
     assert_fatal_error(
       CALL assert IS_ABSOLUTE some/relative/path
-      EXPECT_MESSAGE "expected path:\n  some/relative/path\nto be absolute")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  some/relative/path\nto be absolute")
 
     assert_fatal_error(
       CALL assert NOT IS_ABSOLUTE /some/absolute/path
-      EXPECT_MESSAGE "expected path:\n  /some/absolute/path\n"
-        "not to be absolute")
+      EXPECT_MESSAGE STREQUAL
+        "expected path:\n  /some/absolute/path\nnot to be absolute")
   endsection()
 endsection()
 
@@ -382,12 +393,12 @@ section("regular expression match condition assertions")
   section("it should fail to assert regular expression match conditions")
     assert_fatal_error(
       CALL assert "some string" MATCHES "so.*other.*ing"
-      EXPECT_MESSAGE "expected string:\n  some string\n"
+      EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
         "to match:\n  so.*other.*ing")
 
     assert_fatal_error(
       CALL assert NOT "some string" MATCHES "so.*ing"
-      EXPECT_MESSAGE "expected string:\n  some string\n"
+      EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
         "not to match:\n  so.*ing")
   endsection()
 endsection()
@@ -414,24 +425,27 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 7 LESS 7
-        EXPECT_MESSAGE "expected number:\n  7\nto be less than:\n  7")
+        EXPECT_MESSAGE STREQUAL
+          "expected number:\n  7\nto be less than:\n  7")
 
       assert_fatal_error(
         CALL assert 7 GREATER 7
-        EXPECT_MESSAGE "expected number:\n  7\nto be greater than:\n  7")
+        EXPECT_MESSAGE STREQUAL
+          "expected number:\n  7\nto be greater than:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  7\nnot to be equal to:\n  7")
+        EXPECT_MESSAGE STREQUAL
+          "expected number:\n  7\nnot to be equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 LESS_EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "not to be less than or equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 7 GREATER_EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "not to be greater than or equal to:\n  7")
     endsection()
   endsection()
@@ -454,24 +468,27 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert NOT 7 LESS 13
-        EXPECT_MESSAGE "expected number:\n  7\nnot to be less than:\n  13")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
+          "not to be less than:\n  13")
 
       assert_fatal_error(
         CALL assert 7 GREATER 13
-        EXPECT_MESSAGE "expected number:\n  7\nto be greater than:\n  13")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
+          "to be greater than:\n  13")
 
       assert_fatal_error(
         CALL assert 7 EQUAL 13
-        EXPECT_MESSAGE "expected number:\n  7\nto be equal to:\n  13")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
+          "to be equal to:\n  13")
 
       assert_fatal_error(
         CALL assert NOT 7 LESS_EQUAL 13
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "not to be less than or equal to:\n  13")
 
       assert_fatal_error(
         CALL assert 7 GREATER_EQUAL 13
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "to be greater than or equal to:\n  13")
     endsection()
   endsection()
@@ -494,24 +511,27 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 13 LESS 7
-        EXPECT_MESSAGE "expected number:\n  13\nto be less than:\n  7")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  13\n"
+          "to be less than:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 13 GREATER 7
-        EXPECT_MESSAGE "expected number:\n  13\nnot to be greater than:\n  7")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  13\n"
+          "not to be greater than:\n  7")
 
       assert_fatal_error(
         CALL assert 13 EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  13\nto be equal to:\n  7")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  13\n"
+          "to be equal to:\n  7")
 
       assert_fatal_error(
         CALL assert 13 LESS_EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  13\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  13\n"
           "to be less than or equal to:\n  7")
 
       assert_fatal_error(
         CALL assert NOT 13 GREATER_EQUAL 7
-        EXPECT_MESSAGE "expected number:\n  13\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  13\n"
           "not to be greater than or equal to:\n  7")
     endsection()
   endsection()
@@ -536,25 +556,27 @@ section("number equality condition assertions")
     section("it should fail to assert number equality conditions")
       assert_fatal_error(
         CALL assert 7 LESS  "some string"
-        EXPECT_MESSAGE "expected number:\n  7\nto be less than:\n  some string")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
+          "to be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 GREATER "some string"
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 EQUAL "some string"
-        EXPECT_MESSAGE "expected number:\n  7\nto be equal to:\n  some string")
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
+          "to be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 LESS_EQUAL "some string"
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert 7 GREATER_EQUAL "some string"
-        EXPECT_MESSAGE "expected number:\n  7\n"
+        EXPECT_MESSAGE STREQUAL "expected number:\n  7\n"
           "to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -582,27 +604,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert "some string" STRLESS "some string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "to be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some string" STRGREATER "some string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STREQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "not to be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRLESS_EQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "not to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER_EQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "not to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -625,27 +647,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert NOT "some other string" STRLESS "some string"
-        EXPECT_MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some other string\n"
           "not to be less than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STRGREATER "some string"
-        EXPECT_MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some other string\n"
           "to be greater than:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STREQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some other string\n"
           "to be equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert NOT "some other string" STRLESS_EQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some other string\n"
           "not to be less than or equal to:\n  some string")
 
       assert_fatal_error(
         CALL assert "some other string" STRGREATER_EQUAL "some string"
-        EXPECT_MESSAGE "expected string:\n  some other string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some other string\n"
           "to be greater than or equal to:\n  some string")
     endsection()
   endsection()
@@ -668,27 +690,27 @@ section("string equality condition assertions")
     section("it should fail to assert string equality conditions")
       assert_fatal_error(
         CALL assert "some string" STRLESS "some other string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "to be less than:\n  some other string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER "some other string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "not to be greater than:\n  some other string")
 
       assert_fatal_error(
         CALL assert "some string" STREQUAL "some other string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "to be equal to:\n  some other string")
 
       assert_fatal_error(
         CALL assert "some string" STRLESS_EQUAL "some other string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "to be less than or equal to:\n  some other string")
 
       assert_fatal_error(
         CALL assert NOT "some string" STRGREATER_EQUAL "some other string"
-        EXPECT_MESSAGE "expected string:\n  some string\n"
+        EXPECT_MESSAGE STREQUAL "expected string:\n  some string\n"
           "not to be greater than or equal to:\n  some other string")
     endsection()
   endsection()
@@ -717,26 +739,27 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_LESS 1.02.3
-        EXPECT_MESSAGE "expected version:\n  1.2.3\nto be less than:\n  1.02.3")
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
+          "to be less than:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER 1.02.3
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "to be greater than:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_EQUAL 1.02.3
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "not to be equal to:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS_EQUAL 1.02.3
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "not to be less than or equal to:\n  1.02.3")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_GREATER_EQUAL 1.02.3
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "not to be greater than or equal to:\n  1.02.3")
     endsection()
   endsection()
@@ -759,26 +782,27 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS 1.3.4
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "not to be less than:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER 1.3.4
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "to be greater than:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_EQUAL 1.3.4
-        EXPECT_MESSAGE "expected version:\n  1.2.3\nto be equal to:\n  1.3.4")
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
+          "to be equal to:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert NOT 1.2.3 VERSION_LESS_EQUAL 1.3.4
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "not to be less than or equal to:\n  1.3.4")
 
       assert_fatal_error(
         CALL assert 1.2.3 VERSION_GREATER_EQUAL 1.3.4
-        EXPECT_MESSAGE "expected version:\n  1.2.3\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.2.3\n"
           "to be greater than or equal to:\n  1.3.4")
     endsection()
   endsection()
@@ -801,25 +825,27 @@ section("version equality condition assertions")
     section("it should fail to assert version equality conditions")
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_LESS 1.2.3
-        EXPECT_MESSAGE "expected version:\n  1.3.4\nto be less than:\n  1.2.3")
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.3.4\n"
+          "to be less than:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert NOT 1.3.4 VERSION_GREATER 1.2.3
-        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.3.4\n"
           "not to be greater than:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_EQUAL 1.2.3
-        EXPECT_MESSAGE "expected version:\n  1.3.4\nto be equal to:\n  1.2.3")
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.3.4\n"
+          "to be equal to:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert 1.3.4 VERSION_LESS_EQUAL 1.2.3
-        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.3.4\n"
           "to be less than or equal to:\n  1.2.3")
 
       assert_fatal_error(
         CALL assert NOT 1.3.4 VERSION_GREATER_EQUAL 1.2.3
-        EXPECT_MESSAGE "expected version:\n  1.3.4\n"
+        EXPECT_MESSAGE STREQUAL "expected version:\n  1.3.4\n"
           "not to be greater than or equal to:\n  1.2.3")
     endsection()
   endsection()
@@ -841,12 +867,12 @@ section("path equality condition assertions")
   section("it should fail to assert path equality conditions")
     assert_fatal_error(
       CALL assert "/some/path" PATH_EQUAL "/some/other/path"
-      EXPECT_MESSAGE "expected path:\n  /some/path\n"
+      EXPECT_MESSAGE STREQUAL "expected path:\n  /some/path\n"
         "to be equal to:\n  /some/other/path")
 
     assert_fatal_error(
       CALL assert NOT "/some/path" PATH_EQUAL "/some//path"
-      EXPECT_MESSAGE "expected path:\n  /some/path\n"
+      EXPECT_MESSAGE STREQUAL "expected path:\n  /some/path\n"
         "not to be equal to:\n  /some//path")
   endsection()
 endsection()

--- a/test/assert_execute_process.cmake
+++ b/test/assert_execute_process.cmake
@@ -37,6 +37,14 @@ section("process execution output assertions")
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
       EXPECT_OUTPUT "Hello" ".*!")
+
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+      EXPECT_OUTPUT MATCHES "Hello" ".*!")
+
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+      EXPECT_OUTPUT STREQUAL "Hello world!\n")
   endsection()
 
   section("it should fail to assert a process execution output")
@@ -50,6 +58,28 @@ section("process execution output assertions")
         "  ${CMAKE_COMMAND} -E echo Hello world!\n"
         "to match:\n"
         "  Hello.*earth!")
+
+    assert_fatal_error(
+      CALL assert_execute_process
+        COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+        EXPECT_OUTPUT MATCHES "Hello" ".*earth!"
+      EXPECT_MESSAGE "expected the output:\n"
+        ".*\n"
+        "of command:\n"
+        "  ${CMAKE_COMMAND} -E echo Hello world!\n"
+        "to match:\n"
+        "  Hello.*earth!")
+
+    assert_fatal_error(
+      CALL assert_execute_process
+        COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
+        EXPECT_OUTPUT STREQUAL "Hello earth!\n"
+      EXPECT_MESSAGE "expected the output:\n"
+        ".*\n"
+        "of command:\n"
+        "  ${CMAKE_COMMAND} -E echo Hello world!\n"
+        "to be equal to:\n"
+        "  Hello earth!\n")
   endsection()
 endsection()
 
@@ -60,6 +90,14 @@ section("process execution error assertions")
     assert_execute_process(
       COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
       EXPECT_ERROR "Error creating directory" ".*some-file")
+
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+      EXPECT_ERROR MATCHES "Error creating directory" ".*some-file")
+
+    assert_execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+      EXPECT_ERROR STREQUAL "Error creating directory \"some-file\".\n")
   endsection()
 
   section("it should fail to assert a process execution error")
@@ -73,5 +111,27 @@ section("process execution error assertions")
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"
         "to match:\n"
         "  Error creating directory.*some-other-file")
+
+    assert_fatal_error(
+      CALL assert_execute_process
+        COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+        EXPECT_ERROR MATCHES "Error creating directory" ".*some-other-file"
+      EXPECT_MESSAGE "expected the error:\n"
+        ".*\n"
+        "of command:\n"
+        "  ${CMAKE_COMMAND} -E make_directory some-file\n"
+        "to match:\n"
+        "  Error creating directory.*some-other-file")
+
+    assert_fatal_error(
+      CALL assert_execute_process
+        COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
+        EXPECT_ERROR STREQUAL "Error creating directory \"some-other-file\".\n"
+      EXPECT_MESSAGE "expected the error:\n"
+        ".*\n"
+        "of command:\n"
+        "  ${CMAKE_COMMAND} -E make_directory some-file\n"
+        "to be equal to:\n"
+        "  Error creating directory \"some-other-file\".\n")
   endsection()
 endsection()

--- a/test/assert_fatal_error.cmake
+++ b/test/assert_fatal_error.cmake
@@ -8,9 +8,12 @@ section("it should assert a fatal error message")
     EXPECT_MESSAGE "some fa.*ror message")
 
   assert_fatal_error(
-    CALL message FATAL_ERROR "some fatal error message "
-      "with additional message"
-    EXPECT_MESSAGE "some fa.*ror message with additional message")
+    CALL message FATAL_ERROR "some fatal error message"
+    EXPECT_MESSAGE MATCHES "some fa.*ror message")
+
+  assert_fatal_error(
+    CALL message FATAL_ERROR "some fatal error message"
+    EXPECT_MESSAGE STREQUAL "some fatal error message")
 endsection()
 
 section("it should fail to assert a fatal error message")
@@ -22,10 +25,36 @@ section("it should fail to assert a fatal error message")
 
   assert_fatal_error(
     CALL failed_assertion
-    EXPECT_MESSAGE "expected fatal error message:\n"
+    EXPECT_MESSAGE STREQUAL "expected fatal error message:\n"
       "  some fatal error message\n"
       "to match:\n"
       "  some other fa.*ror message")
+
+  macro(failed_assertion)
+    assert_fatal_error(
+      CALL message FATAL_ERROR "some fatal error message"
+      EXPECT_MESSAGE MATCHES "some other fa.*ror message")
+  endmacro()
+
+  assert_fatal_error(
+    CALL failed_assertion
+    EXPECT_MESSAGE STREQUAL "expected fatal error message:\n"
+      "  some fatal error message\n"
+      "to match:\n"
+      "  some other fa.*ror message")
+
+  macro(failed_assertion)
+    assert_fatal_error(
+      CALL message FATAL_ERROR "some fatal error message"
+      EXPECT_MESSAGE STREQUAL "some other fatal error message")
+  endmacro()
+
+  assert_fatal_error(
+    CALL failed_assertion
+    EXPECT_MESSAGE STREQUAL "expected fatal error message:\n"
+      "  some fatal error message\n"
+      "to be equal to:\n"
+      "  some other fatal error message")
 endsection()
 
 section("it should fail to assert a fatal error message "
@@ -38,6 +67,5 @@ section("it should fail to assert a fatal error message "
 
   assert_fatal_error(
     CALL failed_assertion
-    EXPECT_MESSAGE "expected to receive a fatal error message that matches:\n"
-      "  some message")
+    EXPECT_MESSAGE "expected to receive a fatal error message")
 endsection()

--- a/test/fail.cmake
+++ b/test/fail.cmake
@@ -6,15 +6,15 @@ section("given strings")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail "single line string"
-      EXPECT_MESSAGE "single line string")
+      EXPECT_MESSAGE STREQUAL "single line string")
 
     assert_fatal_error(
       CALL fail "multiple\nlines\nstring"
-      EXPECT_MESSAGE "multiple\nlines\nstring")
+      EXPECT_MESSAGE STREQUAL "multiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" "multiple\nlines\nstring"
-      EXPECT_MESSAGE "single line string\nmultiple\nlines\nstring")
+      EXPECT_MESSAGE STREQUAL "single line string\nmultiple\nlines\nstring")
   endsection()
 endsection()
 
@@ -26,23 +26,24 @@ section("given variables")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail SINGLE
-      EXPECT_MESSAGE "single line variable")
+      EXPECT_MESSAGE STREQUAL "single line variable")
 
     assert_fatal_error(
       CALL fail MULTIPLE
-      EXPECT_MESSAGE "multiple\nlines\nvariable")
+      EXPECT_MESSAGE STREQUAL "multiple\nlines\nvariable")
 
     assert_fatal_error(
       CALL fail CONTAINS_SINGLE
-      EXPECT_MESSAGE "single line variable\nof variable:\n  SINGLE")
+      EXPECT_MESSAGE STREQUAL "single line variable\nof variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE
-      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable")
+      EXPECT_MESSAGE STREQUAL "single line variable\nmultiple\nlines\nvariable")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
-      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+      EXPECT_MESSAGE STREQUAL
+        "single line variable\nmultiple\nlines\nvariable\n"
         "single line variable\nof variable:\n  SINGLE")
   endsection()
 endsection()
@@ -51,53 +52,55 @@ section("given strings and variables")
   section("it should fail with a formatted fatal error message")
     assert_fatal_error(
       CALL fail "single line string" SINGLE
-      EXPECT_MESSAGE "single line string:\n  single line variable")
+      EXPECT_MESSAGE STREQUAL "single line string:\n  single line variable")
 
     assert_fatal_error(
       CALL fail SINGLE "single line string"
-      EXPECT_MESSAGE "single line variable\nsingle line string")
+      EXPECT_MESSAGE STREQUAL "single line variable\nsingle line string")
 
     assert_fatal_error(
       CALL fail "multiple\nlines\nstring" MULTIPLE
-      EXPECT_MESSAGE "multiple\nlines\nstring:\n"
+      EXPECT_MESSAGE STREQUAL "multiple\nlines\nstring:\n"
         "  multiple\n  lines\n  variable")
 
     assert_fatal_error(
       CALL fail MULTIPLE "multiple\nlines\nstring"
-      EXPECT_MESSAGE "multiple\nlines\nvariable\nmultiple\nlines\nstring")
+      EXPECT_MESSAGE STREQUAL
+        "multiple\nlines\nvariable\nmultiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" CONTAINS_SINGLE
-      EXPECT_MESSAGE "single line string:\n  single line variable\n"
+      EXPECT_MESSAGE STREQUAL "single line string:\n  single line variable\n"
         "of variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail CONTAINS_SINGLE "single line string"
-      EXPECT_MESSAGE "single line variable\nof variable:\n  SINGLE\n"
+      EXPECT_MESSAGE STREQUAL "single line variable\nof variable:\n  SINGLE\n"
         "single line string")
 
     assert_fatal_error(
       CALL fail "single line string" "multiple\nlines\nstring"
         SINGLE MULTIPLE CONTAINS_SINGLE
-      EXPECT_MESSAGE "single line string\nmultiple\nlines\nstring:\n"
+      EXPECT_MESSAGE STREQUAL "single line string\nmultiple\nlines\nstring:\n"
         "  single line variable\n  multiple\n  lines\n  variable\n"
         "  single line variable\nof variable:\n  SINGLE")
 
     assert_fatal_error(
       CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
         "single line string" "multiple\nlines\nstring"
-      EXPECT_MESSAGE "single line variable\nmultiple\nlines\nvariable\n"
+      EXPECT_MESSAGE STREQUAL
+        "single line variable\nmultiple\nlines\nvariable\n"
         "single line variable\nof variable:\n  SINGLE\n"
         "single line string\nmultiple\nlines\nstring")
 
     assert_fatal_error(
       CALL fail "single line string" SINGLE "multiple\nlines\nstring" MULTIPLE
-      EXPECT_MESSAGE "single line string:\n  single line variable\n"
+      EXPECT_MESSAGE STREQUAL "single line string:\n  single line variable\n"
         "multiple\nlines\nstring:\n  multiple\n  lines\n  variable")
 
     assert_fatal_error(
       CALL fail SINGLE "single line string" MULTIPLE "multiple\nlines\nstring"
-      EXPECT_MESSAGE "single line variable\nsingle line string:\n"
+      EXPECT_MESSAGE STREQUAL "single line variable\nsingle line string:\n"
         "  multiple\n  lines\n  variable\nmultiple\nlines\nstring")
   endsection()
 endsection()


### PR DESCRIPTION
This pull request resolves #263 by adding options to the `assert_fatal_error` and `assert_execute_process` functions for specifying operators to be used. Two operators are introduced in this pull request: `STREQUAL` and `MATCHES`. This change also updates the documentation and tests accordingly.