### PR TITLE
Add Variable for Globally Defining Variables in Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Adds a new test that processes the given CMake file in script mode.
 add_cmake_script_test(<file> [NAME <name>] [DEFINITIONS <variables>...])
 ```
 
-This function adds a new test that processes the given `<file>` in script mode. If `NAME` is specified, it will use `<name>` as the test name; otherwise, it will use `<file>`.
+This function adds a new test that processes the specified `<file>` in script mode. If `NAME` is provided, `<name>` will be used as the test name; otherwise, the test name will default to `<file>`.
 
-If `DEFINITIONS` is specified, the script is processed with predefined variables listed in `<variables>`. Each entry in `<variables>` should be in the format `<name>=<value>`, where `<name>` is the variable name and `<value>` is the variable value.
+If the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable is defined, the script will be processed with the predefined variables listed in that variable. Each entry should be in the format `<name>=<value>`, where `<name>` is the variable name and `<value>` is its value. If `DEFINITIONS` is specified, additional variables will also be defined.
 
 #### Example
 

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -27,14 +27,16 @@ set(ASSERTION_VERSION 2.0.0)
 #
 # add_cmake_script_test(<file> [NAME <name>] [DEFINITIONS <variables>...])
 #
-# This function adds a new test that processes the given `<file>` in script
-# mode. If `NAME` is specified, it will use `<name>` as the test name;
-# otherwise, it will use `<file>`.
 #
-# If `DEFINITIONS` is specified, the script is processed with predefined
-# variables listed in `<variables>`. Each entry in `<variables>` should be in
-# the format `<name>=<value>`, where `<name>` is the variable name and `<value>`
-# is the variable value.
+# This function adds a new test that processes the specified `<file>` in script
+# mode. If `NAME` is provided, `<name>` will be used as the test name;
+# otherwise, the test name will default to `<file>`.
+#
+# If the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable is defined, the script will be
+# processed with the predefined variables listed in that variable. Each entry
+# should be in the format `<name>=<value>`, where `<name>` is the variable name
+# and `<value>` is its value. If `DEFINITIONS` is specified, additional
+# variables will also be defined.
 function(add_cmake_script_test FILE)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" NAME DEFINITIONS)
 
@@ -48,7 +50,7 @@ function(add_cmake_script_test FILE)
   endif()
 
   set(TEST_COMMAND "${CMAKE_COMMAND}")
-  foreach(DEFINITION IN LISTS ARG_DEFINITIONS)
+  foreach(DEFINITION IN LISTS CMAKE_SCRIPT_TEST_DEFINITIONS ARG_DEFINITIONS)
     list(APPEND TEST_COMMAND -D "${DEFINITION}")
   endforeach()
   list(APPEND TEST_COMMAND -P "${FILE}")

--- a/test/add_cmake_script_test.cmake
+++ b/test/add_cmake_script_test.cmake
@@ -9,7 +9,6 @@ set(CMAKELISTS_HEADER
   "include(${ASSERTION_LIST_FILE})\n"
   "enable_testing()\n")
 
-
 file(REMOVE_RECURSE project)
 file(WRITE project/test.cmake "message(\"all ok\")\n")
 
@@ -41,18 +40,20 @@ section("it should create a new test with the specified name")
     ctest --test-dir project/build -R "^a test$" --no-tests=error)
 endsection()
 
-file(WRITE project/test.cmake
-  "include(\"\${ASSERTION_LIST_FILE}\")\n"
-  "assert(FOO STREQUAL foo)\n")
-
 section("it should create a new test with predefined variables")
+  file(WRITE project/test.cmake
+    "include(\"${ASSERTION_LIST_FILE}\")\n"
+    "assert(FOO STREQUAL foo)\n"
+    "assert(BAR STREQUAL barbar)\n"
+    "assert(BAZ STREQUAL baz)\n")
+
   file(WRITE project/CMakeLists.txt ${CMAKELISTS_HEADER}
-    "add_cmake_script_test(test.cmake\n"
-    "  DEFINES ASSERTION_LIST_FILE=\${ASSERTION_LIST_FILE} FOO=foo)\n")
+    "set(CMAKE_SCRIPT_TEST_DEFINITIONS FOO=foo BAR=bar)\n"
+    "add_cmake_script_test(test.cmake DEFINITIONS BAR=barbar BAZ=baz)\n")
 
   assert_execute_process("${CMAKE_COMMAND}" --fresh -S project -B project/build)
   assert_execute_process(
-    ctest --test-dir project/build -R --no-tests=error)
+    ctest --test-dir project/build --no-tests=error)
 endsection()
 
 file(REMOVE project/test.cmake)


### PR DESCRIPTION
This pull request resolves #269 by adding support for the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable, allowing variables for all tests to be defined globally.