### PR TITLE
Prevent `add_cmake_script_test` from Being Called in Script Mode

### DIFF
--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -27,7 +27,6 @@ set(ASSERTION_VERSION 2.0.0)
 #
 # add_cmake_script_test(<file> [NAME <name>] [DEFINITIONS <variables>...])
 #
-#
 # This function adds a new test that processes the specified `<file>` in script
 # mode. If `NAME` is provided, `<name>` will be used as the test name;
 # otherwise, the test name will default to `<file>`.
@@ -38,8 +37,12 @@ set(ASSERTION_VERSION 2.0.0)
 # and `<value>` is its value. If `DEFINITIONS` is specified, additional
 # variables will also be defined.
 function(add_cmake_script_test FILE)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" NAME DEFINITIONS)
+  if(DEFINED CMAKE_SCRIPT_MODE_FILE)
+    message(SEND_ERROR "Unable to add a new test in script mode")
+    return()
+  endif()
 
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" NAME DEFINITIONS)
   if(NOT DEFINED ARG_NAME)
     set(ARG_NAME "${FILE}")
   endif()
@@ -47,6 +50,7 @@ function(add_cmake_script_test FILE)
   cmake_path(ABSOLUTE_PATH FILE)
   if(NOT EXISTS ${FILE})
     message(SEND_ERROR "Cannot find test file:\n  ${FILE}")
+    return()
   endif()
 
   set(TEST_COMMAND "${CMAKE_COMMAND}")

--- a/test/add_cmake_script_test.cmake
+++ b/test/add_cmake_script_test.cmake
@@ -56,9 +56,19 @@ section("it should create a new test with predefined variables")
     ctest --test-dir project/build --no-tests=error)
 endsection()
 
-file(REMOVE project/test.cmake)
+section("it should fail to create a new test due to script mode")
+  file(WRITE project/script.cmake
+    "include(${ASSERTION_LIST_FILE})\n"
+    "add_cmake_script_test(test.cmake)\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -P project/script.cmake
+    EXPECT_ERROR "Unable to add a new test in script mode")
+endsection()
 
 section("it should fail to create a new test due to a non-existent file")
+  file(REMOVE project/test.cmake)
+
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" --fresh -S project -B project/build
     EXPECT_ERROR "Cannot find test file:.*test.cmake")


### PR DESCRIPTION
This pull request resolves #271 by preventing `add_cmake_script_test` from being called in script mode, displaying an error message if the `CMAKE_SCRIPT_MODE_FILE` variable is defined.