### PR TITLE
Add Support to Check for Errors in Assert Call Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ assert_call(
   EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
 ```
 
-This function performs an assertion on the function or macro named `<command>`, called with the specified `<arguments>`. It currently only allows asserting whether the given command throws a fatal error message that satisfies the expected message.
+This function performs an assertion on the function or macro named `<command>`, called with the specified `<arguments>`. It currently only allows asserting whether the given command receives an error message that satisfies the expected message.
 
 If `MATCHES` is specified, it asserts whether the received message matches `<message>`. If `STREQUAL` is specified, it asserts whether the received message is equal to `<message>`. If nothing is specified, it defaults to the `MATCHES` parameter.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ assert_execute_process(
   git -C "${CMAKE_STARTER_DIR}" rev-parse --is-inside-work-tree)
 
 assert_call(git_clone https://github.com GITHUB_DIR
-  EXPECT_FATAL_ERROR "failed to clone 'https://github.com'")
+  EXPECT_ERROR "failed to clone 'https://github.com'")
 ```
 
 ### Test Creation
@@ -175,7 +175,7 @@ Performs an assertion on the given command call.
 ```cmake
 assert_call(
   [CALL] <command> [<arguments>...]
-  EXPECT_FATAL_ERROR [MATCHES|STREQUAL] <message>...)
+  EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
 ```
 
 This function performs an assertion on the function or macro named `<command>`, called with the specified `<arguments>`. It currently only allows asserting whether the given command throws a fatal error message that satisfies the expected message.
@@ -193,7 +193,7 @@ endfunction()
 
 assert_call(
   CALL throw_fatal_error "some message"
-  EXPECT_FATAL_ERROR STREQUAL "some message")
+  EXPECT_ERROR STREQUAL "some message")
 ```
 
 The above example asserts whether the call to `throw_fatal_error("some message")` throws a fatal error message equal to `some message`. If it somehow does not capture any fatal error message, it will throw the following fatal error message:

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -358,7 +358,7 @@ endfunction()
 #
 # assert_call(
 #   [CALL] <command> [<arguments>...]
-#   EXPECT_FATAL_ERROR [MATCHES|STREQUAL] <message>...)
+#   EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
 #
 # This function performs an assertion on the function or macro named
 # `<command>`, called with the specified `<arguments>`. It currently only allows
@@ -373,19 +373,19 @@ endfunction()
 # If more than one `<message>` string is given, they are concatenated into a
 # single message with no separators.
 function(assert_call)
-  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;EXPECT_FATAL_ERROR")
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "CALL;EXPECT_ERROR")
 
   if(NOT DEFINED ARG_CALL)
     set(ARG_CALL ${ARG_UNPARSED_ARGUMENTS})
   endif()
 
-  list(GET ARG_EXPECT_FATAL_ERROR 0 OPERATOR)
+  list(GET ARG_EXPECT_ERROR 0 OPERATOR)
   if(OPERATOR MATCHES ^MATCHES|STREQUAL$)
-    list(REMOVE_AT ARG_EXPECT_FATAL_ERROR 0)
+    list(REMOVE_AT ARG_EXPECT_ERROR 0)
   else()
     set(OPERATOR "MATCHES")
   endif()
-  string(JOIN "" EXPECTED_FATAL_ERROR ${ARG_EXPECT_FATAL_ERROR})
+  string(JOIN "" EXPECTED_ERROR ${ARG_EXPECT_ERROR})
 
   # Override the `message` function if it has not been overridden.
   get_property(MESSAGE_MOCKED GLOBAL PROPERTY _assert_internal_message_mocked)
@@ -444,13 +444,13 @@ function(assert_call)
   # Assert the captured fatal error message with the expected message.
   get_property(ACTUAL_MESSAGE GLOBAL PROPERTY captured_fatal_error)
   string(STRIP "${ACTUAL_MESSAGE}" ACTUAL_MESSAGE)
-  if(NOT "${ACTUAL_MESSAGE}" ${OPERATOR} "${EXPECTED_FATAL_ERROR}")
+  if(NOT "${ACTUAL_MESSAGE}" ${OPERATOR} "${EXPECTED_ERROR}")
     if(OPERATOR STREQUAL "MATCHES")
       fail("expected fatal error message" ACTUAL_MESSAGE
-        "to match" EXPECTED_FATAL_ERROR)
+        "to match" EXPECTED_ERROR)
     else()
       fail("expected fatal error message" ACTUAL_MESSAGE
-        "to be equal to" EXPECTED_FATAL_ERROR)
+        "to be equal to" EXPECTED_ERROR)
     endif()
   endif()
 endfunction()

--- a/test/test_add_test.cmake
+++ b/test/test_add_test.cmake
@@ -57,13 +57,8 @@ section("it should create a new test with predefined variables")
 endsection()
 
 section("it should fail to create a new test due to script mode")
-  file(WRITE project/script.cmake
-    "include(${ASSERTION_LIST_FILE})\n"
-    "add_cmake_script_test(test.cmake)\n")
-
-  assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" -P project/script.cmake
-    EXPECT_ERROR "Unable to add a new test in script mode")
+  assert_call(add_cmake_script_test test.cmake
+    EXPECT_ERROR STREQUAL "Unable to add a new test in script mode")
 endsection()
 
 section("it should fail to create a new test due to a non-existent file")

--- a/test/test_assert.cmake
+++ b/test/test_assert.cmake
@@ -42,10 +42,10 @@ section("assert boolean conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert FALSE
-      EXPECT_FATAL_ERROR STREQUAL "expected:\n  FALSE\nto resolve to true")
+      EXPECT_ERROR STREQUAL "expected:\n  FALSE\nto resolve to true")
 
     assert_call(assert NOT TRUE
-      EXPECT_FATAL_ERROR STREQUAL "expected:\n  NOT TRUE\nto resolve to true")
+      EXPECT_ERROR STREQUAL "expected:\n  NOT TRUE\nto resolve to true")
   endsection()
 endsection()
 
@@ -60,11 +60,11 @@ section("assert command existence conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert COMMAND non_existing_command
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected command:\n  non_existing_command\nto be defined")
 
     assert_call(assert NOT COMMAND existing_command
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected command:\n  existing_command\nnot to be defined")
   endsection()
 endsection()
@@ -77,10 +77,10 @@ section("assert policy existence conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert POLICY CMPXXXX
-      EXPECT_FATAL_ERROR STREQUAL "expected policy:\n  CMPXXXX\nto exist")
+      EXPECT_ERROR STREQUAL "expected policy:\n  CMPXXXX\nto exist")
 
     assert_call(assert NOT POLICY CMP0000
-      EXPECT_FATAL_ERROR STREQUAL "expected policy:\n  CMP0000\nnot to exist")
+      EXPECT_ERROR STREQUAL "expected policy:\n  CMP0000\nnot to exist")
   endsection()
 endsection()
 
@@ -100,11 +100,11 @@ section("assert target existence conditions")
       "add_custom_target(some_target)\n"
       "\n"
       "assert_call(assert TARGET non_existing_target\n"
-      "  EXPECT_FATAL_ERROR STREQUAL\n"
+      "  EXPECT_ERROR STREQUAL\n"
       "    \"expected target:\\n  non_existing_target\\nto exist\")\n"
       "\n"
       "assert_call(assert NOT TARGET some_target\n"
-      "  EXPECT_FATAL_ERROR STREQUAL\n"
+      "  EXPECT_ERROR STREQUAL\n"
       "    \"expected target:\\n  some_target\\nnot to exist\")\n")
   endsection()
 endsection()
@@ -125,11 +125,11 @@ section("assert test existence conditions")
       "add_test(NAME some_test COMMAND some_command)\n"
       "\n"
       "assert_call(assert TEST non_existing_test\n"
-      "  EXPECT_FATAL_ERROR STREQUAL\n"
+      "  EXPECT_ERROR STREQUAL\n"
       "    \"expected test:\\n  non_existing_test\\nto exist\")\n"
       "\n"
       "assert_call(assert NOT TEST some_test\n"
-      "  EXPECT_FATAL_ERROR STREQUAL\n"
+      "  EXPECT_ERROR STREQUAL\n"
       "    \"expected test:\\n  some_test\\nnot to exist\")\n")
   endsection()
 endsection()
@@ -145,11 +145,11 @@ section("assert variable existence conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert DEFINED NON_EXISTING_VARIABLE
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected variable:\n  NON_EXISTING_VARIABLE\nto be defined")
 
     assert_call(assert NOT DEFINED EXISTING_VARIABLE
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected variable:\n  EXISTING_VARIABLE\nnot to be defined")
   endsection()
 endsection()
@@ -170,12 +170,12 @@ section("assert list element existence conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert "other element" IN_LIST SOME_LIST
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  other element\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  other element\n"
         "to exist in:\n  some element\;some other element\n"
         "of variable:\n  SOME_LIST")
 
     assert_call(assert NOT "some element" IN_LIST SOME_LIST
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some element\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some element\n"
         "not to exist in:\n  some element\;some other element\n"
         "of variable:\n  SOME_LIST")
   endsection()
@@ -192,11 +192,10 @@ section("assert path existence conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert EXISTS non_existing_file
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected path:\n  non_existing_file\nto exist")
+      EXPECT_ERROR STREQUAL "expected path:\n  non_existing_file\nto exist")
 
     assert_call(assert NOT EXISTS some_file
-      EXPECT_FATAL_ERROR STREQUAL "expected path:\n  some_file\nnot to exist")
+      EXPECT_ERROR STREQUAL "expected path:\n  some_file\nnot to exist")
   endsection()
 endsection()
 
@@ -214,12 +213,11 @@ section("assert path readability conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_READABLE non_readable_file
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  non_readable_file\nto be readable")
 
     assert_call(assert NOT IS_READABLE some_file
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected path:\n  some_file\nnot to be readable")
+      EXPECT_ERROR STREQUAL "expected path:\n  some_file\nnot to be readable")
   endsection()
 endsection()
 
@@ -236,12 +234,11 @@ section("assert path writability conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_WRITABLE non_writable_file
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  non_writable_file\nto be writable")
 
     assert_call(assert NOT IS_WRITABLE some_file
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected path:\n  some_file\nnot to be writable")
+      EXPECT_ERROR STREQUAL "expected path:\n  some_file\nnot to be writable")
   endsection()
 endsection()
 
@@ -262,11 +259,10 @@ section("assert executable path conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_EXECUTABLE some_file
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected path:\n  some_file\nto be an executable")
+      EXPECT_ERROR STREQUAL "expected path:\n  some_file\nto be an executable")
 
     assert_call(assert NOT IS_EXECUTABLE some_executable
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  some_executable\nnot to be an executable")
   endsection()
 endsection()
@@ -286,11 +282,11 @@ section("assert file recency conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert old_file IS_NEWER_THAN new_file
-      EXPECT_FATAL_ERROR STREQUAL "expected file:\n  old_file\n"
+      EXPECT_ERROR STREQUAL "expected file:\n  old_file\n"
         "to be newer than:\n  new_file")
 
     assert_call(assert NOT new_file IS_NEWER_THAN old_file
-      EXPECT_FATAL_ERROR STREQUAL "expected file:\n  new_file\n"
+      EXPECT_ERROR STREQUAL "expected file:\n  new_file\n"
         "not to be newer than:\n  old_file")
   endsection()
 endsection()
@@ -306,11 +302,10 @@ section("assert directory path conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_DIRECTORY some_file
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected path:\n  some_file\nto be a directory")
+      EXPECT_ERROR STREQUAL "expected path:\n  some_file\nto be a directory")
 
     assert_call(assert NOT IS_DIRECTORY some_directory
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  some_directory\nnot to be a directory")
   endsection()
 endsection()
@@ -326,11 +321,11 @@ section("assert symbolic link path conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_SYMLINK some_file
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  some_file\nto be a symbolic link")
 
     assert_call(assert NOT IS_SYMLINK some_symlink
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  some_symlink\nnot to be a symbolic link")
   endsection()
 endsection()
@@ -343,11 +338,11 @@ section("assert absolute path conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert IS_ABSOLUTE some/relative/path
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  some/relative/path\nto be absolute")
 
     assert_call(assert NOT IS_ABSOLUTE /some/absolute/path
-      EXPECT_FATAL_ERROR STREQUAL
+      EXPECT_ERROR STREQUAL
         "expected path:\n  /some/absolute/path\nnot to be absolute")
   endsection()
 endsection()
@@ -365,11 +360,11 @@ section("assert regular expression match conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert "some string" MATCHES "so.*other.*ing"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to match:\n  so.*other.*ing")
 
     assert_call(assert NOT "some string" MATCHES "so.*ing"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to match:\n  so.*ing")
   endsection()
 endsection()
@@ -389,11 +384,11 @@ section("assert path equality conditions")
 
   section("it should fail to assert conditions")
     assert_call(assert "/some/path" PATH_EQUAL "/some/other/path"
-      EXPECT_FATAL_ERROR STREQUAL "expected path:\n  /some/path\n"
+      EXPECT_ERROR STREQUAL "expected path:\n  /some/path\n"
         "to be equal to:\n  /some/other/path")
 
     assert_call(assert NOT "/some/path" PATH_EQUAL "/some//path"
-      EXPECT_FATAL_ERROR STREQUAL "expected path:\n  /some/path\n"
+      EXPECT_ERROR STREQUAL "expected path:\n  /some/path\n"
         "not to be equal to:\n  /some//path")
   endsection()
 endsection()

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -2,54 +2,59 @@ cmake_minimum_required(VERSION 3.24)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 
-section("it should assert a fatal error message")
-  assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_ERROR "some fa.*ror message")
+section("it should assert error messages")
+  assert_call(message FATAL_ERROR "an error message"
+    EXPECT_ERROR "an e...r message")
+
+  assert_call(message SEND_ERROR "an error message"
+    EXPECT_ERROR "an e...r message")
 
   assert_call(
-    CALL message FATAL_ERROR "some fatal error message"
-    EXPECT_ERROR "some fa.*ror message")
+    CALL message FATAL_ERROR "an error message"
+    EXPECT_ERROR "an e...r message")
 
-  assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_ERROR MATCHES "some fa.*ror message")
+  assert_call(message FATAL_ERROR "an error message"
+    EXPECT_ERROR MATCHES "an e...r message")
 
-  assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_ERROR STREQUAL "some fatal error message")
+  assert_call(message FATAL_ERROR "an error message"
+    EXPECT_ERROR STREQUAL "an error message")
 endsection()
 
-section("it should fail to assert a fatal error message")
+section("it should fail to assert error messages")
   macro(failed_assertion)
-    assert_call(message FATAL_ERROR "some fatal error message"
-      EXPECT_ERROR MATCHES "some other fa.*ror message")
+    assert_call(message FATAL_ERROR "an error message"
+      EXPECT_ERROR "an..... e...r message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_ERROR STREQUAL
-      "expected fatal error message:\n"
-      "  some fatal error message\n"
-      "to match:\n"
-      "  some other fa.*ror message")
+    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
+      "to match:\n  an..... e...r message")
 
   macro(failed_assertion)
-    assert_call(message FATAL_ERROR "some fatal error message"
-      EXPECT_ERROR STREQUAL "some other fatal error message")
+    assert_call(message SEND_ERROR "an error message"
+      EXPECT_ERROR MATCHES "an..... e...r message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_ERROR STREQUAL
-      "expected fatal error message:\n"
-      "  some fatal error message\n"
-      "to be equal to:\n"
-      "  some other fatal error message")
+    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
+      "to match:\n  an..... e...r message")
+
+  macro(failed_assertion)
+    assert_call(message FATAL_ERROR "an error message"
+      EXPECT_ERROR STREQUAL "another error message")
+  endmacro()
+
+  assert_call(failed_assertion
+    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
+      "to be equal to:\n  another error message")
 endsection()
 
-section("it should fail to assert a fatal error message "
-  "because there is nothing to assert")
-
+section("it should fail to assert error messages "
+  "due to no error being received")
   macro(failed_assertion)
-    assert_call(message "some message" EXPECT_ERROR "some message")
+    assert_call(message "a message" EXPECT_ERROR "a message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_ERROR "expected to receive a fatal error message")
+    EXPECT_ERROR "expected to receive an error message")
 endsection()

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -4,27 +4,27 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 
 section("it should assert a fatal error message")
   assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_FATAL_ERROR "some fa.*ror message")
+    EXPECT_ERROR "some fa.*ror message")
 
   assert_call(
     CALL message FATAL_ERROR "some fatal error message"
-    EXPECT_FATAL_ERROR "some fa.*ror message")
+    EXPECT_ERROR "some fa.*ror message")
 
   assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_FATAL_ERROR MATCHES "some fa.*ror message")
+    EXPECT_ERROR MATCHES "some fa.*ror message")
 
   assert_call(message FATAL_ERROR "some fatal error message"
-    EXPECT_FATAL_ERROR STREQUAL "some fatal error message")
+    EXPECT_ERROR STREQUAL "some fatal error message")
 endsection()
 
 section("it should fail to assert a fatal error message")
   macro(failed_assertion)
     assert_call(message FATAL_ERROR "some fatal error message"
-      EXPECT_FATAL_ERROR MATCHES "some other fa.*ror message")
+      EXPECT_ERROR MATCHES "some other fa.*ror message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "expected fatal error message:\n"
       "  some fatal error message\n"
       "to match:\n"
@@ -32,11 +32,11 @@ section("it should fail to assert a fatal error message")
 
   macro(failed_assertion)
     assert_call(message FATAL_ERROR "some fatal error message"
-      EXPECT_FATAL_ERROR STREQUAL "some other fatal error message")
+      EXPECT_ERROR STREQUAL "some other fatal error message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "expected fatal error message:\n"
       "  some fatal error message\n"
       "to be equal to:\n"
@@ -47,9 +47,9 @@ section("it should fail to assert a fatal error message "
   "because there is nothing to assert")
 
   macro(failed_assertion)
-    assert_call(message "some message" EXPECT_FATAL_ERROR "some message")
+    assert_call(message "some message" EXPECT_ERROR "some message")
   endmacro()
 
   assert_call(failed_assertion
-    EXPECT_FATAL_ERROR "expected to receive a fatal error message")
+    EXPECT_ERROR "expected to receive a fatal error message")
 endsection()

--- a/test/test_assert_number.cmake
+++ b/test/test_assert_number.cmake
@@ -22,23 +22,20 @@ section("assert number equality conditions given equal numbers")
 
   section("it should fail to assert conditions")
     assert_call(assert 7 LESS 7
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected number:\n  7\nto be less than:\n  7")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nto be less than:\n  7")
 
     assert_call(assert 7 GREATER 7
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected number:\n  7\nto be greater than:\n  7")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nto be greater than:\n  7")
 
     assert_call(assert NOT 7 EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL
-        "expected number:\n  7\nnot to be equal to:\n  7")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nnot to be equal to:\n  7")
 
     assert_call(assert NOT 7 LESS_EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "not to be less than or equal to:\n  7")
 
     assert_call(assert NOT 7 GREATER_EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "not to be greater than or equal to:\n  7")
   endsection()
 endsection()
@@ -60,23 +57,20 @@ section("assert number equality conditions given a lesser number")
 
   section("it should fail to assert conditions")
     assert_call(assert NOT 7 LESS 13
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
-        "not to be less than:\n  13")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nnot to be less than:\n  13")
 
     assert_call(assert 7 GREATER 13
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
-        "to be greater than:\n  13")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nto be greater than:\n  13")
 
     assert_call(assert 7 EQUAL 13
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
-        "to be equal to:\n  13")
+      EXPECT_ERROR STREQUAL "expected number:\n  7\nto be equal to:\n  13")
 
     assert_call(assert NOT 7 LESS_EQUAL 13
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "not to be less than or equal to:\n  13")
 
     assert_call(assert 7 GREATER_EQUAL 13
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be greater than or equal to:\n  13")
   endsection()
 endsection()
@@ -98,23 +92,21 @@ section("assert number equality conditions given a greater number")
 
   section("it should fail to assert conditions")
     assert_call(assert 13 LESS 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  13\n"
-        "to be less than:\n  7")
+      EXPECT_ERROR STREQUAL "expected number:\n  13\nto be less than:\n  7")
 
     assert_call(assert NOT 13 GREATER 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  13\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  13\n"
         "not to be greater than:\n  7")
 
     assert_call(assert 13 EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  13\n"
-        "to be equal to:\n  7")
+      EXPECT_ERROR STREQUAL "expected number:\n  13\nto be equal to:\n  7")
 
     assert_call(assert 13 LESS_EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  13\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  13\n"
         "to be less than or equal to:\n  7")
 
     assert_call(assert NOT 13 GREATER_EQUAL 7
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  13\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  13\n"
         "not to be greater than or equal to:\n  7")
   endsection()
 endsection()
@@ -138,23 +130,23 @@ section("assert number equality conditions given a non-number")
 
   section("it should fail to assert conditions")
     assert_call(assert 7 LESS  "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be less than:\n  some string")
 
     assert_call(assert 7 GREATER "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be greater than:\n  some string")
 
     assert_call(assert 7 EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be equal to:\n  some string")
 
     assert_call(assert 7 LESS_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be less than or equal to:\n  some string")
 
     assert_call(assert 7 GREATER_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected number:\n  7\n"
+      EXPECT_ERROR STREQUAL "expected number:\n  7\n"
         "to be greater than or equal to:\n  some string")
   endsection()
 endsection()

--- a/test/test_assert_process.cmake
+++ b/test/test_assert_process.cmake
@@ -10,7 +10,7 @@ section("assert process executions")
   section("it should fail to assert process executions")
     assert_call(
       CALL assert_execute_process "${CMAKE_COMMAND}" -E true EXPECT_FAIL
-      EXPECT_FATAL_ERROR STREQUAL "expected command:\n"
+      EXPECT_ERROR STREQUAL "expected command:\n"
         "  ${CMAKE_COMMAND} -E true\nto fail")
   endsection()
 endsection()
@@ -26,7 +26,7 @@ section("assert failed process executions")
   section("it should fail to assert failed process executions")
     assert_call(
       CALL assert_execute_process "${CMAKE_COMMAND}" -E make_directory some-file
-      EXPECT_FATAL_ERROR STREQUAL "expected command:\n"
+      EXPECT_ERROR STREQUAL "expected command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"
         "not to fail with error:\n"
         "  Error creating directory \"some-file\".")
@@ -53,7 +53,7 @@ section("assert process execution outputs")
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
         EXPECT_OUTPUT "Hello" ".*earth!"
-      EXPECT_FATAL_ERROR STREQUAL "expected the output:\n"
+      EXPECT_ERROR STREQUAL "expected the output:\n"
         "  Hello world!\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E echo Hello world!\n"
@@ -64,7 +64,7 @@ section("assert process execution outputs")
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
         EXPECT_OUTPUT MATCHES "Hello" ".*earth!"
-      EXPECT_FATAL_ERROR STREQUAL "expected the output:\n"
+      EXPECT_ERROR STREQUAL "expected the output:\n"
         "  Hello world!\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E echo Hello world!\n"
@@ -75,7 +75,7 @@ section("assert process execution outputs")
       CALL assert_execute_process
         COMMAND "${CMAKE_COMMAND}" -E echo "Hello world!"
         EXPECT_OUTPUT STREQUAL "Hello earth!\n"
-      EXPECT_FATAL_ERROR STREQUAL "expected the output:\n"
+      EXPECT_ERROR STREQUAL "expected the output:\n"
         "  Hello world!\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E echo Hello world!\n"
@@ -102,33 +102,39 @@ section("assert process execution errors")
   endsection()
 
   section("it should fail to assert process execution errors")
-    assert_call(
-      CALL assert_execute_process
-        COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-        EXPECT_ERROR "Error creating directory" ".*some-other-file"
-      EXPECT_FATAL_ERROR STREQUAL "expected the error:\n"
+    macro(failed_assert)
+      assert_execute_process("${CMAKE_COMMAND}" -E make_directory some-file
+        EXPECT_ERROR "Error creating directory" ".*some-other-file")
+    endmacro()
+
+    assert_call(failed_assert
+      EXPECT_ERROR STREQUAL "expected the error:\n"
         "  Error creating directory \"some-file\".\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"
         "to match:\n"
         "  Error creating directory.*some-other-file")
 
-    assert_call(
-      CALL assert_execute_process
-        COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-        EXPECT_ERROR MATCHES "Error creating directory" ".*some-other-file"
-      EXPECT_FATAL_ERROR STREQUAL "expected the error:\n"
+    macro(failed_assert)
+      assert_execute_process("${CMAKE_COMMAND}" -E make_directory some-file
+        EXPECT_ERROR MATCHES "Error creating directory" ".*some-other-file")
+    endmacro()
+
+    assert_call(failed_assert
+      EXPECT_ERROR STREQUAL "expected the error:\n"
         "  Error creating directory \"some-file\".\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"
         "to match:\n"
         "  Error creating directory.*some-other-file")
 
-    assert_call(
-      CALL assert_execute_process
-        COMMAND "${CMAKE_COMMAND}" -E make_directory some-file
-        EXPECT_ERROR STREQUAL "Error creating directory \"some-other-file\"."
-      EXPECT_FATAL_ERROR STREQUAL "expected the error:\n"
+    macro(failed_assert)
+      assert_execute_process("${CMAKE_COMMAND}" -E make_directory some-file
+        EXPECT_ERROR STREQUAL "Error creating directory \"some-other-file\".")
+    endmacro()
+
+    assert_call(failed_assert
+      EXPECT_ERROR STREQUAL "expected the error:\n"
         "  Error creating directory \"some-file\".\n"
         "of command:\n"
         "  ${CMAKE_COMMAND} -E make_directory some-file\n"

--- a/test/test_assert_string.cmake
+++ b/test/test_assert_string.cmake
@@ -22,23 +22,23 @@ section("assert string equality conditions given equal strings")
 
   section("it should fail to assert conditions")
     assert_call(assert "some string" STRLESS "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to be less than:\n  some string")
 
     assert_call(assert "some string" STRGREATER "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to be greater than:\n  some string")
 
     assert_call(assert NOT "some string" STREQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to be equal to:\n  some string")
 
     assert_call(assert NOT "some string" STRLESS_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to be less than or equal to:\n  some string")
 
     assert_call(assert NOT "some string" STRGREATER_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to be greater than or equal to:\n  some string")
   endsection()
 endsection()
@@ -60,23 +60,23 @@ section("assert string equality conditions given a lesser string")
 
   section("it should fail to assert conditions")
     assert_call(assert NOT "some other string" STRLESS "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some other string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some other string\n"
         "not to be less than:\n  some string")
 
     assert_call(assert "some other string" STRGREATER "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some other string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some other string\n"
         "to be greater than:\n  some string")
 
     assert_call(assert "some other string" STREQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some other string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some other string\n"
         "to be equal to:\n  some string")
 
     assert_call(assert NOT "some other string" STRLESS_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some other string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some other string\n"
         "not to be less than or equal to:\n  some string")
 
     assert_call(assert "some other string" STRGREATER_EQUAL "some string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some other string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some other string\n"
         "to be greater than or equal to:\n  some string")
   endsection()
 endsection()
@@ -98,23 +98,23 @@ section("assert string equality conditions given a greater string")
 
   section("it should fail to assert conditions")
     assert_call(assert "some string" STRLESS "some other string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to be less than:\n  some other string")
 
     assert_call(assert NOT "some string" STRGREATER "some other string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to be greater than:\n  some other string")
 
     assert_call(assert "some string" STREQUAL "some other string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to be equal to:\n  some other string")
 
     assert_call(assert "some string" STRLESS_EQUAL "some other string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "to be less than or equal to:\n  some other string")
 
     assert_call(assert NOT "some string" STRGREATER_EQUAL "some other string"
-      EXPECT_FATAL_ERROR STREQUAL "expected string:\n  some string\n"
+      EXPECT_ERROR STREQUAL "expected string:\n  some string\n"
         "not to be greater than or equal to:\n  some other string")
   endsection()
 endsection()

--- a/test/test_assert_version.cmake
+++ b/test/test_assert_version.cmake
@@ -23,23 +23,23 @@ section("assert version equality conditions given equal versions")
 
   section("it should fail to assert conditions")
     assert_call(assert 1.2.3 VERSION_LESS 1.02.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "to be less than:\n  1.02.3")
 
     assert_call(assert 1.2.3 VERSION_GREATER 1.02.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "to be greater than:\n  1.02.3")
 
     assert_call(assert NOT 1.2.3 VERSION_EQUAL 1.02.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "not to be equal to:\n  1.02.3")
 
     assert_call(assert NOT 1.2.3 VERSION_LESS_EQUAL 1.02.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "not to be less than or equal to:\n  1.02.3")
 
     assert_call(assert NOT 1.2.3 VERSION_GREATER_EQUAL 1.02.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "not to be greater than or equal to:\n  1.02.3")
   endsection()
 endsection()
@@ -61,23 +61,23 @@ section("assert version equality conditions given a lesser version")
 
   section("it should fail to assert conditions")
     assert_call(assert NOT 1.2.3 VERSION_LESS 1.3.4
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "not to be less than:\n  1.3.4")
 
     assert_call(assert 1.2.3 VERSION_GREATER 1.3.4
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "to be greater than:\n  1.3.4")
 
     assert_call(assert 1.2.3 VERSION_EQUAL 1.3.4
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "to be equal to:\n  1.3.4")
 
     assert_call(assert NOT 1.2.3 VERSION_LESS_EQUAL 1.3.4
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "not to be less than or equal to:\n  1.3.4")
 
     assert_call(assert 1.2.3 VERSION_GREATER_EQUAL 1.3.4
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.2.3\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.2.3\n"
         "to be greater than or equal to:\n  1.3.4")
   endsection()
 endsection()
@@ -99,23 +99,23 @@ section("assert version equality conditions given a greater version")
 
   section("it should fail to assert conditions")
     assert_call(assert 1.3.4 VERSION_LESS 1.2.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.3.4\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.3.4\n"
         "to be less than:\n  1.2.3")
 
     assert_call(assert NOT 1.3.4 VERSION_GREATER 1.2.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.3.4\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.3.4\n"
         "not to be greater than:\n  1.2.3")
 
     assert_call(assert 1.3.4 VERSION_EQUAL 1.2.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.3.4\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.3.4\n"
         "to be equal to:\n  1.2.3")
 
     assert_call(assert 1.3.4 VERSION_LESS_EQUAL 1.2.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.3.4\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.3.4\n"
         "to be less than or equal to:\n  1.2.3")
 
     assert_call(assert NOT 1.3.4 VERSION_GREATER_EQUAL 1.2.3
-      EXPECT_FATAL_ERROR STREQUAL "expected version:\n  1.3.4\n"
+      EXPECT_ERROR STREQUAL "expected version:\n  1.3.4\n"
         "not to be greater than or equal to:\n  1.2.3")
   endsection()
 endsection()

--- a/test/test_fail.cmake
+++ b/test/test_fail.cmake
@@ -4,13 +4,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 
 section("it should fail with formatted fatal error messages given strings")
   assert_call(fail "single line string"
-    EXPECT_FATAL_ERROR STREQUAL "single line string")
+    EXPECT_ERROR STREQUAL "single line string")
 
   assert_call(fail "multiple\nlines\nstring"
-    EXPECT_FATAL_ERROR STREQUAL "multiple\nlines\nstring")
+    EXPECT_ERROR STREQUAL "multiple\nlines\nstring")
 
   assert_call(fail "single line string" "multiple\nlines\nstring"
-    EXPECT_FATAL_ERROR STREQUAL "single line string\nmultiple\nlines\nstring")
+    EXPECT_ERROR STREQUAL "single line string\nmultiple\nlines\nstring")
 endsection()
 
 set(SINGLE "single line variable")
@@ -18,22 +18,17 @@ set(MULTIPLE "multiple\nlines\nvariable")
 set(CONTAINS_SINGLE SINGLE)
 
 section("it should fail with formatted fatal error messages given variables")
-  assert_call(fail SINGLE
-    EXPECT_FATAL_ERROR STREQUAL "single line variable")
-
-  assert_call(fail MULTIPLE
-    EXPECT_FATAL_ERROR STREQUAL "multiple\nlines\nvariable")
+  assert_call(fail SINGLE EXPECT_ERROR STREQUAL "single line variable")
+  assert_call(fail MULTIPLE EXPECT_ERROR STREQUAL "multiple\nlines\nvariable")
 
   assert_call(fail CONTAINS_SINGLE
-    EXPECT_FATAL_ERROR STREQUAL
-      "single line variable\nof variable:\n  SINGLE")
+    EXPECT_ERROR STREQUAL "single line variable\nof variable:\n  SINGLE")
 
   assert_call(fail SINGLE MULTIPLE
-    EXPECT_FATAL_ERROR STREQUAL
-      "single line variable\nmultiple\nlines\nvariable")
+    EXPECT_ERROR STREQUAL "single line variable\nmultiple\nlines\nvariable")
 
   assert_call(fail SINGLE MULTIPLE CONTAINS_SINGLE
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line variable\nmultiple\nlines\nvariable\n"
       "single line variable\nof variable:\n  SINGLE")
 endsection()
@@ -41,31 +36,30 @@ endsection()
 section("it should fail with formatted fatal error messages "
   "given strings and variables")
   assert_call(fail "single line string" SINGLE
-    EXPECT_FATAL_ERROR STREQUAL "single line string:\n  single line variable")
+    EXPECT_ERROR STREQUAL "single line string:\n  single line variable")
 
   assert_call(fail SINGLE "single line string"
-    EXPECT_FATAL_ERROR STREQUAL "single line variable\nsingle line string")
+    EXPECT_ERROR STREQUAL "single line variable\nsingle line string")
 
   assert_call(fail "multiple\nlines\nstring" MULTIPLE
-    EXPECT_FATAL_ERROR STREQUAL "multiple\nlines\nstring:\n"
+    EXPECT_ERROR STREQUAL "multiple\nlines\nstring:\n"
       "  multiple\n  lines\n  variable")
 
   assert_call(fail MULTIPLE "multiple\nlines\nstring"
-    EXPECT_FATAL_ERROR STREQUAL
-      "multiple\nlines\nvariable\nmultiple\nlines\nstring")
+    EXPECT_ERROR STREQUAL "multiple\nlines\nvariable\nmultiple\nlines\nstring")
 
   assert_call(fail "single line string" CONTAINS_SINGLE
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line string:\n  single line variable\nof variable:\n  SINGLE")
 
   assert_call(fail CONTAINS_SINGLE "single line string"
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line variable\nof variable:\n  SINGLE\nsingle line string")
 
   assert_call(
     CALL fail "single line string" "multiple\nlines\nstring"
       SINGLE MULTIPLE CONTAINS_SINGLE
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line string\nmultiple\nlines\nstring:\n"
       "  single line variable\n  multiple\n  lines\n  variable\n"
       "  single line variable\nof variable:\n  SINGLE")
@@ -73,19 +67,19 @@ section("it should fail with formatted fatal error messages "
   assert_call(
     CALL fail SINGLE MULTIPLE CONTAINS_SINGLE
       "single line string" "multiple\nlines\nstring"
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line variable\nmultiple\nlines\nvariable\n"
       "single line variable\nof variable:\n  SINGLE\n"
       "single line string\nmultiple\nlines\nstring")
 
   assert_call(
     CALL fail "single line string" SINGLE "multiple\nlines\nstring" MULTIPLE
-    EXPECT_FATAL_ERROR STREQUAL
+    EXPECT_ERROR STREQUAL
       "single line string:\n  single line variable\n"
       "multiple\nlines\nstring:\n  multiple\n  lines\n  variable")
 
   assert_call(
     CALL fail SINGLE "single line string" MULTIPLE "multiple\nlines\nstring"
-    EXPECT_FATAL_ERROR STREQUAL "single line variable\nsingle line string:\n"
+    EXPECT_ERROR STREQUAL "single line variable\nsingle line string:\n"
       "  multiple\n  lines\n  variable\nmultiple\nlines\nstring")
 endsection()


### PR DESCRIPTION
This pull request resolves #279 by adding support for checking errors from both `message(FATAL_ERROR)` and `message(SEND_ERROR)`. It also renames `EXPECT_FATAL_ERROR` to `EXPECT_ERROR` and updates the tests accordingly.