### PR TITLE
Modify Assert Call to Capture All Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,28 +178,30 @@ assert_call(
   EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
 ```
 
-This function performs an assertion on the function or macro named `<command>`, called with the specified `<arguments>`. It currently only allows asserting whether the given command receives an error message that satisfies the expected message.
+This function asserts the behavior of the function or macro named `<command>`, called with the specified `<arguments>`. It currently only supports asserting whether the given command receives error messages that satisfy the expected message. It captures all errors from the `message` function and compares them with the expected message. Each captured error is concatenated with new lines as separators.
 
-If `MATCHES` is specified, it asserts whether the received message matches `<message>`. If `STREQUAL` is specified, it asserts whether the received message is equal to `<message>`. If nothing is specified, it defaults to the `MATCHES` parameter.
+If `MATCHES` is specified, it asserts whether the captured messages match `<message>`. If `STREQUAL` is specified, it asserts whether the captured messages are equal to `<message>`. If neither is specified, it defaults to the `MATCHES` parameter.
 
 If more than one `<message>` string is given, they are concatenated into a single message with no separators.
 
 #### Example
 
 ```cmake
-function(throw_fatal_error MESSAGE)
-  message(FATAL_ERROR "${MESSAGE}")
+function(send_errors)
+  foreach(MESSAGE IN LISTS ARGV)
+    message(SEND_ERROR "${MESSAGE} error")
+  endforeach()
 endfunction()
 
 assert_call(
-  CALL throw_fatal_error "some message"
-  EXPECT_ERROR STREQUAL "some message")
+  CALL send_errors first second
+  EXPECT_ERROR STREQUAL "first error\nsecond error")
 ```
 
-The above example asserts whether the call to `throw_fatal_error("some message")` throws a fatal error message equal to `some message`. If it somehow does not capture any fatal error message, it will throw the following fatal error message:
+The above example asserts whether the call to `send_errors(first second)` receives errors equal to `first error\nsecond error`. If it does not receive any errors, it will throw the following error:
 
 ```
-expected to receive a fatal error message
+expected to receive an error message
 ```
 
 ### `assert_execute_process`

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -360,16 +360,18 @@ endfunction()
 #   [CALL] <command> [<arguments>...]
 #   EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
 #
-# This function performs an assertion on the function or macro named
-# `<command>`, called with the specified `<arguments>`. It currently only allows
-# asserting whether the given command receives an error message that satisfies
-# the expected message.
-
-# If `MATCHES` is specified, it asserts whether the received message matches
-# `<message>`. If `STREQUAL` is specified, it asserts whether the received
-# message is equal to `<message>`. If nothing is specified, it defaults to the
+# This function asserts the behavior of the function or macro named `<command>`,
+# called with the specified `<arguments>`. It currently only supports asserting
+# whether the given command receives error messages that satisfy the expected
+# message. It captures all errors from the `message` function and compares them
+# with the expected message. Each captured error is concatenated with new lines
+# as separators.
+#
+# If `MATCHES` is specified, it asserts whether the captured messages match
+# `<message>`. If `STREQUAL` is specified, it asserts whether the captured
+# messages are equal to `<message>`. If neither is specified, it defaults to the
 # `MATCHES` parameter.
-
+#
 # If more than one `<message>` string is given, they are concatenated into a
 # single message with no separators.
 function(assert_call)

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -2,51 +2,57 @@ cmake_minimum_required(VERSION 3.24)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
 
+function(throw_errors)
+  message(SEND_ERROR "a send error message")
+  message(FATAL_ERROR "a fatal error message")
+endfunction()
+
 section("it should assert error messages")
-  assert_call(message FATAL_ERROR "an error message"
-    EXPECT_ERROR "an e...r message")
+  assert_call(throw_errors EXPECT_ERROR
+    "a se.*or message\n"
+    "a fa.*or message")
 
-  assert_call(message SEND_ERROR "an error message"
-    EXPECT_ERROR "an e...r message")
+  assert_call(CALL throw_errors EXPECT_ERROR
+    "a se.*or message\n"
+    "a fa.*or message")
 
-  assert_call(
-    CALL message FATAL_ERROR "an error message"
-    EXPECT_ERROR "an e...r message")
+  assert_call(throw_errors EXPECT_ERROR MATCHES
+    "a se.*or message\n"
+    "a fa.*or message")
 
-  assert_call(message FATAL_ERROR "an error message"
-    EXPECT_ERROR MATCHES "an e...r message")
-
-  assert_call(message FATAL_ERROR "an error message"
-    EXPECT_ERROR STREQUAL "an error message")
+  assert_call(throw_errors EXPECT_ERROR STREQUAL
+    "a send error message\n"
+    "a fatal error message")
 endsection()
 
 section("it should fail to assert error messages")
-  macro(failed_assertion)
-    assert_call(message FATAL_ERROR "an error message"
-      EXPECT_ERROR "an..... e...r message")
+  macro(assert_failures)
+    assert_call(throw_errors EXPECT_ERROR
+      "another se.*or message\n"
+      "another fa.*or message")
   endmacro()
 
-  assert_call(failed_assertion
-    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
-      "to match:\n  an..... e...r message")
+  assert_call(assert_failures EXPECT_ERROR STREQUAL
+    "expected error message:\n"
+    "  a send error message\n"
+    "  a fatal error message\n"
+    "to match:\n"
+    "  another se.*or message\n"
+    "  another fa.*or message")
 
-  macro(failed_assertion)
-    assert_call(message SEND_ERROR "an error message"
-      EXPECT_ERROR MATCHES "an..... e...r message")
+  macro(assert_failures)
+    assert_call(throw_errors EXPECT_ERROR
+      "another send error message\n"
+      "another fatal error message")
   endmacro()
 
-  assert_call(failed_assertion
-    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
-      "to match:\n  an..... e...r message")
-
-  macro(failed_assertion)
-    assert_call(message FATAL_ERROR "an error message"
-      EXPECT_ERROR STREQUAL "another error message")
-  endmacro()
-
-  assert_call(failed_assertion
-    EXPECT_ERROR STREQUAL "expected error message:\n  an error message\n"
-      "to be equal to:\n  another error message")
+  assert_call(assert_failures EXPECT_ERROR STREQUAL
+    "expected error message:\n"
+    "  a send error message\n"
+    "  a fatal error message\n"
+    "to match:\n"
+    "  another send error message\n"
+    "  another fatal error message")
 endsection()
 
 section("it should fail to assert error messages "
@@ -55,6 +61,6 @@ section("it should fail to assert error messages "
     assert_call(message "a message" EXPECT_ERROR "a message")
   endmacro()
 
-  assert_call(failed_assertion
-    EXPECT_ERROR "expected to receive an error message")
+  assert_call(failed_assertion EXPECT_ERROR
+    "expected to receive an error message")
 endsection()


### PR DESCRIPTION
This pull request resolves #285 by modifying the `assert_call` function to capture all errors instead of just one error during the command call. It also updates the documentation and tests accordingly.