### PR TITLE
Add Support to Assert Function Call Not Receive Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,12 @@ Performs an assertion on the given command call.
 ```cmake
 assert_call(
   [CALL] <command> [<arguments>...]
-  EXPECT_ERROR [MATCHES|STREQUAL] <message>...)
+  [EXPECT_ERROR [MATCHES|STREQUAL] <message>...])
 ```
 
-This function asserts the behavior of the function or macro named `<command>`, called with the specified `<arguments>`. It currently only supports asserting whether the given command receives error messages that satisfy the expected message. It captures all errors from the `message` function and compares them with the expected message. Each captured error is concatenated with new lines as separators.
+This function asserts whether the function or macro named `<command>`, called with the specified `<arguments>`, does not receive any errors. Internally, the function captures all errors from the `message` function. Each captured error is concatenated with new lines as separators.
 
-If `MATCHES` is specified, it asserts whether the captured messages match `<message>`. If `STREQUAL` is specified, it asserts whether the captured messages are equal to `<message>`. If neither is specified, it defaults to the `MATCHES` parameter.
-
-If more than one `<message>` string is given, they are concatenated into a single message with no separators.
+If `EXPECT_ERROR` is specified, it instead asserts whether the call to the function or macro received errors that satisfy the expected message. If `MATCHES` is specified, it asserts whether the received errors match `<message>`. If `STREQUAL` is specified, it asserts whether the received errors are equal to `<message>`. If neither is specified, it defaults to the `MATCHES` parameter. If more than one `<message>` string is given, they are concatenated into a single message with no separators.
 
 #### Example
 
@@ -201,7 +199,7 @@ assert_call(
 The above example asserts whether the call to `send_errors(first second)` receives errors equal to `first error\nsecond error`. If it does not receive any errors, it will throw the following error:
 
 ```
-expected to receive an error message
+expected to receive errors
 ```
 
 ### `assert_execute_process`

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -7,60 +7,70 @@ function(throw_errors)
   message(FATAL_ERROR "a fatal error message")
 endfunction()
 
-section("it should assert error messages")
-  assert_call(throw_errors EXPECT_ERROR
-    "a se.*or message\n"
-    "a fa.*or message")
+section("assert command calls")
+  section("it should assert command calls")
+    assert_call(message DEBUG "a debug message")
+    assert_call(CALL message DEBUG "a debug message")
+  endsection()
 
-  assert_call(CALL throw_errors EXPECT_ERROR
-    "a se.*or message\n"
-    "a fa.*or message")
-
-  assert_call(throw_errors EXPECT_ERROR MATCHES
-    "a se.*or message\n"
-    "a fa.*or message")
-
-  assert_call(throw_errors EXPECT_ERROR STREQUAL
-    "a send error message\n"
-    "a fatal error message")
+  section("it should fail to assert a command call")
+    assert_call(assert_call throw_errors EXPECT_ERROR STREQUAL
+      "expected not to receive errors:\n"
+      "  a send error message\n"
+      "  a fatal error message")
+  endsection()
 endsection()
 
-section("it should fail to assert error messages")
-  macro(assert_failures)
+section("assert command call errors")
+  section("it should assert command call errors")
     assert_call(throw_errors EXPECT_ERROR
-      "another se.*or message\n"
-      "another fa.*or message")
-  endmacro()
+      "a se.*or message\n"
+      "a fa.*or message")
 
-  assert_call(assert_failures EXPECT_ERROR STREQUAL
-    "expected error message:\n"
-    "  a send error message\n"
-    "  a fatal error message\n"
-    "to match:\n"
-    "  another se.*or message\n"
-    "  another fa.*or message")
+    assert_call(throw_errors EXPECT_ERROR MATCHES
+      "a se.*or message\n"
+      "a fa.*or message")
 
-  macro(assert_failures)
-    assert_call(throw_errors EXPECT_ERROR
-      "another send error message\n"
-      "another fatal error message")
-  endmacro()
+    assert_call(throw_errors EXPECT_ERROR STREQUAL
+      "a send error message\n"
+      "a fatal error message")
+  endsection()
 
-  assert_call(assert_failures EXPECT_ERROR STREQUAL
-    "expected error message:\n"
-    "  a send error message\n"
-    "  a fatal error message\n"
-    "to match:\n"
-    "  another send error message\n"
-    "  another fatal error message")
-endsection()
+  section("it should fail to assert command call errors")
+    macro(assert_failures)
+      assert_call(message DEBUG "a debug message"
+        EXPECT_ERROR "a debug message")
+    endmacro()
 
-section("it should fail to assert error messages "
-  "due to no error being received")
-  macro(failed_assertion)
-    assert_call(message "a message" EXPECT_ERROR "a message")
-  endmacro()
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected to receive errors")
 
-  assert_call(failed_assertion EXPECT_ERROR
-    "expected to receive an error message")
+    macro(assert_failures)
+      assert_call(throw_errors EXPECT_ERROR
+        "another se.*or message\n"
+        "another fa.*or message")
+    endmacro()
+
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected errors:\n"
+      "  a send error message\n"
+      "  a fatal error message\n"
+      "to match:\n"
+      "  another se.*or message\n"
+      "  another fa.*or message")
+
+    macro(assert_failures)
+      assert_call(throw_errors EXPECT_ERROR
+        "another send error message\n"
+        "another fatal error message")
+    endmacro()
+
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected errors:\n"
+      "  a send error message\n"
+      "  a fatal error message\n"
+      "to match:\n"
+      "  another send error message\n"
+      "  another fatal error message")
+  endsection()
 endsection()


### PR DESCRIPTION
This pull request resolves #284 by modifying the `EXPECT_ERROR` option in the `assert_call` function to be optional. If not specified, the function will assert that the command call does not receive any errors. This change also updates the tests and documentation accordingly.