### PR TITLE
Add Support to Assert Command Calls to Receive Warning Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,17 @@ Performs an assertion on the given command call.
 ```cmake
 assert_call(
   [CALL] <command> [<arguments>...]
-  [EXPECT_ERROR [MATCHES|STREQUAL] <message>...])
+  [EXPECT_ERROR [MATCHES|STREQUAL] <message>...]
+  [EXPECT_WARNING [MATCHES|STREQUAL] <message>...])
 ```
 
-This function asserts whether the function or macro named `<command>`, called with the specified `<arguments>`, does not receive any errors. Internally, the function captures all errors from the `message` function. Each captured error is concatenated with new lines as separators.
+This function asserts whether the function or macro named `<command>`, called with the specified `<arguments>`, does not receive any errors or warnings. Internally, the function captures all errors and warnings from the `message` function. Each captured error and warning is concatenated with new lines as separators.
 
-If `EXPECT_ERROR` is specified, it instead asserts whether the call to the function or macro received errors that satisfy the expected message. If `MATCHES` is specified, it asserts whether the received errors match `<message>`. If `STREQUAL` is specified, it asserts whether the received errors are equal to `<message>`. If neither is specified, it defaults to the `MATCHES` parameter. If more than one `<message>` string is given, they are concatenated into a single message with no separators.
+If `EXPECT_ERROR` or `EXPECT_WARNING` is specified, it instead asserts whether the call to the function or macro received errors or warnings that satisfy the expected message.
+
+In both `EXPECT_ERROR` and `EXPECT_WARNING` options, `MATCHES` and `STREQUAL` are used to determine the operator for comparing the received errors and warnings with the expected message. If `MATCHES` is specified, they are compared using regular expression matching. If `STREQUAL` is specified, they are compared lexicographically. If neither is specified, it defaults to `MATCHES`.
+
+If more than one `<message>` string is given, they are concatenated into a single message with no separators.
 
 #### Example
 

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -7,17 +7,27 @@ function(throw_errors)
   message(FATAL_ERROR "a fatal error message")
 endfunction()
 
+function(throw_warnings)
+  message(WARNING "a warning message")
+  message(AUTHOR_WARNING "an author warning message")
+endfunction()
+
 section("assert command calls")
   section("it should assert command calls")
     assert_call(message DEBUG "a debug message")
     assert_call(CALL message DEBUG "a debug message")
   endsection()
 
-  section("it should fail to assert a command call")
+  section("it should fail to assert command calls")
     assert_call(assert_call throw_errors EXPECT_ERROR STREQUAL
       "expected not to receive errors:\n"
       "  a send error message\n"
       "  a fatal error message")
+
+    assert_call(assert_call throw_warnings EXPECT_ERROR STREQUAL
+      "expected not to receive warnings:\n"
+      "  a warning message\n"
+      "  an author warning message")
   endsection()
 endsection()
 
@@ -72,5 +82,59 @@ section("assert command call errors")
       "to match:\n"
       "  another send error message\n"
       "  another fatal error message")
+  endsection()
+endsection()
+
+section("assert command call warnings")
+  section("it should assert command call warnings")
+    assert_call(throw_warnings EXPECT_WARNING
+      "a wa.*ng message\n"
+      "an au.*ng message")
+
+    assert_call(throw_warnings EXPECT_WARNING MATCHES
+      "a wa.*ng message\n"
+      "an au.*ng message")
+
+    assert_call(throw_warnings EXPECT_WARNING STREQUAL
+      "a warning message\n"
+      "an author warning message")
+  endsection()
+
+  section("it should fail to assert command call warnings")
+    macro(assert_failures)
+      assert_call(message DEBUG "a debug message"
+        EXPECT_WARNING "a debug message")
+    endmacro()
+
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected to receive warnings")
+
+    macro(assert_failures)
+      assert_call(throw_warnings EXPECT_WARNING
+        "another wa.*ng message\n"
+        "another au.*ng message")
+    endmacro()
+
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected warnings:\n"
+      "  a warning message\n"
+      "  an author warning message\n"
+      "to match:\n"
+      "  another wa.*ng message\n"
+      "  another au.*ng message")
+
+    macro(assert_failures)
+      assert_call(throw_warnings EXPECT_WARNING
+        "another warning message\n"
+        "another author warning message")
+    endmacro()
+
+    assert_call(assert_failures EXPECT_ERROR STREQUAL
+      "expected warnings:\n"
+      "  a warning message\n"
+      "  an author warning message\n"
+      "to match:\n"
+      "  another warning message\n"
+      "  another author warning message")
   endsection()
 endsection()


### PR DESCRIPTION
This pull request resolves #287 by adding a new `EXPECT_WARNINGS` option to the `assert_call` function, allowing it to assert whether a command call receives warning messages or not. This change also updates the documentation and tests accordingly.