### PR TITLE
Allow Specification of Only Variable Name in Test Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ add_cmake_script_test(
 
 This function adds a new test that processes the specified `<file>` in script mode. If `NAME` is provided, `<name>` will be used as the test name; otherwise, the test name will default to `<file>`.
 
-If the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable is defined, the script will be processed with the predefined variables listed in that variable. Each entry should be in the format `<name>=<value>`, where `<name>` is the variable name and `<value>` is its value. If `DEFINITIONS` is specified, additional variables will also be defined.
+If the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable is defined, the script will be processed with the predefined variables listed in that variable. Each entry should be in the format `<name>=<value>`, where `<name>` is the variable name and `<value>` is its value. If `<value>` is not provided, it uses the value of a variable named `<name>` in the current CMake scope. If `DEFINITIONS` is specified, additional variables will also be defined.
 
 #### Example
 
 ```cmake
-add_cmake_script_test(test_foo.cmake NAME "Test Foo" DEFINITIONS FOO=foo BAR=bar)
+set(BAR bar)
+add_cmake_script_test(test_foo.cmake NAME "Test Foo" DEFINITIONS FOO=foo BAR)
 ```
 
 The example above adds a new test named `Test Foo`, which processes the `test_foo.cmake` file in script mode with predefined `FOO` and `BAR` variables.

--- a/cmake/Assertion.cmake
+++ b/cmake/Assertion.cmake
@@ -35,8 +35,9 @@ set(ASSERTION_VERSION 2.0.0)
 # If the `CMAKE_SCRIPT_TEST_DEFINITIONS` variable is defined, the script will be
 # processed with the predefined variables listed in that variable. Each entry
 # should be in the format `<name>=<value>`, where `<name>` is the variable name
-# and `<value>` is its value. If `DEFINITIONS` is specified, additional
-# variables will also be defined.
+# and `<value>` is its value. If `<value>` is not provided, it uses the value of
+# a variable named `<name>` in the current CMake scope. If `DEFINITIONS` is
+# specified, additional variables will also be defined.
 function(add_cmake_script_test)
   if(DEFINED CMAKE_SCRIPT_MODE_FILE)
     message(SEND_ERROR "Unable to add a new test in script mode")
@@ -61,6 +62,9 @@ function(add_cmake_script_test)
 
   set(TEST_COMMAND "${CMAKE_COMMAND}")
   foreach(DEFINITION IN LISTS CMAKE_SCRIPT_TEST_DEFINITIONS ARG_DEFINITIONS)
+    if(NOT DEFINITION MATCHES =)
+      set(DEFINITION "${DEFINITION}=${${DEFINITION}}")
+    endif()
     list(APPEND TEST_COMMAND -D "${DEFINITION}")
   endforeach()
   list(APPEND TEST_COMMAND -P "${ARG_FILE}")

--- a/test/test_add_test.cmake
+++ b/test/test_add_test.cmake
@@ -49,7 +49,8 @@ section("it should create a new test with predefined variables")
 
   file(WRITE project/CMakeLists.txt ${CMAKELISTS_HEADER}
     "set(CMAKE_SCRIPT_TEST_DEFINITIONS FOO=foo BAR=bar)\n"
-    "add_cmake_script_test(test.cmake DEFINITIONS BAR=barbar BAZ=baz)\n")
+    "set(BAR barbar)\n"
+    "add_cmake_script_test(test.cmake DEFINITIONS BAR BAZ=baz)\n")
 
   assert_execute_process("${CMAKE_COMMAND}" --fresh -S project -B project/build)
   assert_execute_process(


### PR DESCRIPTION
This pull request resolves #291 by allowing the test definitions in the `add_cmake_script_test` function to be specified without a value, defaulting to use the value of a variable with the same name in the CMake scope. This change also updates the documentation and tests accordingly.