### PR TITLE
Prepend CMake Module Path with Assertion Module Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ include(Assertion)
 if(ASSERTION_ENABLE_TESTS)
   enable_testing()
 
+  list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_MODULE_PATH)
+
   add_cmake_script_test(test/test_add_test.cmake)
   add_cmake_script_test(test/test_assert_call.cmake)
   add_cmake_script_test(test/test_assert_number.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ project(
 option(ASSERTION_ENABLE_TESTS "Enable test targets.")
 option(ASSERTION_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
-include(cmake/Assertion.cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+include(Assertion)
 
 if(ASSERTION_ENABLE_TESTS)
   enable_testing()
@@ -27,7 +28,8 @@ endif()
 
 if(ASSERTION_ENABLE_INSTALL)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/AssertionConfig.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/Assertion.cmake)\n")
+    "list(PREPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})\n"
+    "include(Assertion)\n")
 
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/AssertionConfigVersion.cmake

--- a/test/test_add_test.cmake
+++ b/test/test_add_test.cmake
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
-  RESULT_VARIABLE ASSERTION_LIST_FILE)
+include(Assertion RESULT_VARIABLE ASSERTION_LIST_FILE)
 
 set(CMAKELISTS_HEADER
   "cmake_minimum_required(VERSION 3.24)\n"

--- a/test/test_assert.cmake
+++ b/test/test_assert.cmake
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake
-  RESULT_VARIABLE ASSERTION_LIST_FILE)
+include(Assertion RESULT_VARIABLE ASSERTION_LIST_FILE)
 
 file(MAKE_DIRECTORY sample-project)
 

--- a/test/test_assert_call.cmake
+++ b/test/test_assert_call.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 function(throw_errors)
   message(SEND_ERROR "a send error message")

--- a/test/test_assert_number.cmake
+++ b/test/test_assert_number.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 set(SEVEN_VAR 7)
 set(THIRTEEN_VAR 13)

--- a/test/test_assert_process.cmake
+++ b/test/test_assert_process.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 section("assert process executions")
   section("it should assert process executions")

--- a/test/test_assert_string.cmake
+++ b/test/test_assert_string.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 set(STRING_VAR "a string")
 set(OTHER_STRING_VAR "another string")

--- a/test/test_assert_version.cmake
+++ b/test/test_assert_version.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 set(VERSION_VAR 1.2.3)
 set(VERSIONN_VAR 1.02.3)

--- a/test/test_fail.cmake
+++ b/test/test_fail.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Assertion.cmake)
+include(Assertion)
 
 section("it should fail with formatted fatal error messages given strings")
   assert_call(fail "single line string"


### PR DESCRIPTION
This pull request resolves #299 by prepending the `CMAKE_MODULE_PATH` variable with the `Assertion.cmake` module's directory, allowing the module to be included using its name instead of the full path. This change also updates how the module is included in the test files.